### PR TITLE
[Feat] Toggle 컴포넌트 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.0",
     "framer-motion": "^11.3.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/client/src/components/Toggle/index.stories.tsx
+++ b/client/src/components/Toggle/index.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { Meta } from "@storybook/react";
 import Component, { ToggleProps } from "./index";
 
@@ -11,9 +12,15 @@ const meta = {
 export default meta;
 
 const Toggle = (args: ToggleProps) => {
-    return <Component {...args} />;
+    const [isLeftSelected, setIsLeftSelected] = useState(args.isLeftSelected);
+
+    const handleToggle = () => {
+        setIsLeftSelected((prevIsSelected) => !prevIsSelected);
+    };
+
+    return <Component {...args} isLeftSelected={isLeftSelected} handleToggle={handleToggle} />;
 };
 
 export const Default = (args: ToggleProps) => (
-    <Toggle {...args} leftText="Now" rightText="Before" />
+    <Toggle {...args} leftText="Now" rightText="Before" isLeftSelected={true} />
 );

--- a/client/src/components/Toggle/index.stories.tsx
+++ b/client/src/components/Toggle/index.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta } from "@storybook/react";
+import Component, { ToggleProps } from "./index";
+
+const meta = {
+    title: "Toggle",
+    component: Component,
+    tags: ["autodocs"],
+    argTypes: {},
+} as Meta;
+
+export default meta;
+
+const Toggle = (args: ToggleProps) => {
+    return <Component {...args} />;
+};
+
+export const Default = (args: ToggleProps) => (
+    <Toggle {...args} leftText="Now" rightText="Before" />
+);

--- a/client/src/components/Toggle/index.tsx
+++ b/client/src/components/Toggle/index.tsx
@@ -1,16 +1,75 @@
+import { useEffect, useRef, useState } from "react";
+
 export interface ToggleProps {
     leftText: string;
     rightText: string;
+    isLeftSelected: boolean;
+    handleToggle: (val: boolean) => void;
 }
 
-export default function Toggle({ leftText, rightText }: ToggleProps) {
+const PADDING = 8;
+
+export default function Toggle({ leftText, rightText, isLeftSelected, handleToggle }: ToggleProps) {
+    const leftTextRef = useRef<HTMLDivElement>(null);
+    const rightTextRef = useRef<HTMLDivElement>(null);
+    const [selectedWidth, setSelectedWidth] = useState<number>(0);
+    const [selectedTranslate, setSelectedTranslate] = useState<number>(0);
+
+    const toggleBackgroundDynamicStyle = {
+        width: selectedWidth,
+        transform: `translateX(${selectedTranslate}px)`,
+    };
+
+    useEffect(() => {
+        if (document.fonts) {
+            document.fonts.ready.then(calculateTextWidth);
+        } else {
+            window.addEventListener("load", calculateTextWidth);
+            return () => window.removeEventListener("load", calculateTextWidth);
+        }
+    }, []);
+
+    useEffect(() => {
+        calculateTextWidth();
+    }, [isLeftSelected, leftText, rightText]);
+
+    const calculateTextWidth = () => {
+        if (!leftTextRef.current || !rightTextRef.current) {
+            return;
+        }
+
+        const leftWidth = leftTextRef.current.offsetWidth;
+        const rightWidth = rightTextRef.current.offsetWidth;
+        setSelectedWidth(isLeftSelected ? leftWidth : rightWidth);
+
+        const translate = isLeftSelected ? PADDING : leftWidth + PADDING * 2;
+        setSelectedTranslate(translate);
+    };
+
+    const handleToggleClick = () => {
+        handleToggle(!isLeftSelected);
+    };
+
     return (
-        <div className="bg-n-white rounded-700 p-300 flex">
-            <div>
-                <p className="h-body-2-bold">{leftText}</p>
+        <div
+            className="bg-n-white rounded-700 p-300 inline-flex items-center gap-300 cursor-pointer relative select-none"
+            onClick={handleToggleClick}
+        >
+            <div
+                className="rounded-500 bg-n-black absolute top-300 left-0 h-[30px] transition-all duration-500"
+                style={toggleBackgroundDynamicStyle}
+            ></div>
+            <div
+                ref={leftTextRef}
+                className="h-body-2-bold py-200 px-300 z-10 mix-blend-difference text-n-white"
+            >
+                {leftText}
             </div>
-            <div>
-                <p className="h-body-2-bold">{rightText}</p>
+            <div
+                ref={rightTextRef}
+                className="h-body-2-bold py-200 px-300 z-10 mix-blend-difference text-n-white"
+            >
+                {rightText}
             </div>
         </div>
     );

--- a/client/src/components/Toggle/index.tsx
+++ b/client/src/components/Toggle/index.tsx
@@ -1,0 +1,17 @@
+export interface ToggleProps {
+    leftText: string;
+    rightText: string;
+}
+
+export default function Toggle({ leftText, rightText }: ToggleProps) {
+    return (
+        <div className="bg-n-white rounded-700 p-300 flex">
+            <div>
+                <p className="h-body-2-bold">{leftText}</p>
+            </div>
+            <div>
+                <p className="h-body-2-bold">{rightText}</p>
+            </div>
+        </div>
+    );
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2715,6 +2715,13 @@ citty@^0.1.6:
   dependencies:
     consola "^3.2.3"
 
+class-variance-authority@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.7.0.tgz#1c3134d634d80271b1837452b06d821915954522"
+  integrity sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==
+  dependencies:
+    clsx "2.0.0"
+
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
@@ -2740,6 +2747,11 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
+
+clsx@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
+  integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
 
 color-convert@^1.9.0:
   version "1.9.3"


### PR DESCRIPTION
## 🖥️ Preview


https://github.com/user-attachments/assets/95f9307b-66c9-419f-a493-19d4d4aeaa83


close #3

## ✏️ 한 일

- [x] Toggle 컴포넌트 구현
- [x] Toggle 애니메이션 구현

## ❗️ 발생한 이슈 (해결 방안)

### background box width 오류

Toggle 컴포넌트의 애니메이션을 위해 컴포넌트를 클릭 시 현재 선택된 텍스트의 width를 가져와서 black background의 width에 세팅해주기로 했다.

|우리가 원하는 UI|실제로 첫 렌더링 시 적용되는 UI|
|---|---|
|![image](https://github.com/user-attachments/assets/ad7f104f-51b9-4fdc-9307-64849e334d1a)|![image](https://github.com/user-attachments/assets/93e35718-2fcd-418b-8f5c-9d2b9042992a)|

첫 렌더링 시 왼쪽과 같이 ‘Now’ 텍스트에 맞게 black background 크기가 맞춰져야하는데, 실제로는 오른쪽과 같이 약간 작게 width가 잡히는 경향이 있었다.

이유를 생각해보는데, 첫 렌더링 시에만 저런 width 오차가 발생하는 것으로 보아 폰트를 가져오기 전에 width가 잘못 설정된 것 같았다.

```tsx
 useEffect(() => {
    if (document.fonts) {
        document.fonts.ready.then(calculateTextWidth);
    } else {
        window.addEventListener("load", calculateTextWidth);
        return () => window.removeEventListener("load", calculateTextWidth);
    }
}, []);
```

위와 같이 폰트를 로드한 후 text width를 calculate 하도록 수정했다.

`document.fonts.ready`를 사용하여 모든 폰트가 로드된 시점을 감지하고, 폰트가 로드된 후에 너비를 다시 계산합니다. 만약 `document.fonts`를 지원하지 않는 브라우저의 경우, `window`의 `load` 이벤트를 사용하여 폰트 로드가 완료된 후에 너비를 계산합니다.

- `document.fonts` : **FontFaceSet 인터페이스**를 반환한다. FontFaceSet은 CSS Font Loading API이다. CSS는 @font-face 규칙을 사용하여 다운로드할 폰트를 지정하고 font-family 속성으로 요소에 적용한다. 이때 CSS Font Loading API는 작성자가 폰트 페이스가 가져와지고 로드되는 시점을 제어하고 추적할 수 있도록 하여 이 문제를 해결한다. 따라서 FontFaceSet을 사용하여 폰트 다운로드를 트리거하고 로딩 완료를 모니터링할 수 있다.
- `window.load` : 리소스와 그것에 의존하는 리소스들의 로딩이 완료되면 실행된다. 따라서 선언된 font의 로딩도 끝난 후 실행된다.

## ❓ 논의가 필요한 사항
