### PR TITLE
[Fix] tsconfig에 alias 선언 형식 추가

### DIFF
--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -22,7 +22,12 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noFallthroughCasesInSwitch": true,
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["src/*"]
+        }
     },
     "include": ["src"]
 }


### PR DESCRIPTION
## 🖥️ Preview

없음

## ✏️ 한 일

- [x] tsconfig에 alias 설정 추가

## ❗️ 발생한 이슈 (해결 방안)

### Vite config에서 설정한 alias 설정이 안 먹는 문제

vite.config 파일 뿐만 아니라 tsconfig에도 alias를 적용해줘야 typescript에서 alias 인식이 가능하다.

## ❓ 논의가 필요한 사항
