### PR TITLE
[Feat] Scroll 컴포넌트 구현

### DIFF
--- a/client/public/assets/icon/arrow-down.svg
+++ b/client/public/assets/icon/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg width="73" height="32" viewBox="0 0 73 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.5 6L36.5 26L68.5 6" stroke="#DFDFDF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/components/Scroll/index.stories.tsx
+++ b/client/src/components/Scroll/index.stories.tsx
@@ -6,7 +6,8 @@ const meta = {
     component: Component,
     tags: ["autodocs"],
     argTypes: {
-        isChecked: { control: "boolean" },
+        type: { description: "Scroll 색상 타입" },
+        children: { description: "Scroll에 들어갈 텍스트" },
     },
 } as Meta;
 

--- a/client/src/components/Scroll/index.stories.tsx
+++ b/client/src/components/Scroll/index.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta } from "@storybook/react";
+import Component, { ScrollProps } from "./index";
+
+const meta = {
+    title: "Scroll",
+    component: Component,
+    tags: ["autodocs"],
+    argTypes: {
+        isChecked: { control: "boolean" },
+    },
+} as Meta;
+
+export default meta;
+
+const Scroll = (args: ScrollProps) => {
+    return <Component {...args} />;
+};
+
+export const Light = (args: ScrollProps) => (
+    <Scroll {...args} type="light">
+        <span className="h-body-2-regular">
+            이벤트에 대해 궁금하다면 <span className="h-body-2-bold">스크롤</span>해 보세요
+        </span>
+    </Scroll>
+);
+
+export const Dark = (args: ScrollProps) => (
+    <Scroll {...args} type="dark">
+        <span className="h-body-2-regular">
+            이벤트에 대해 궁금하다면 <span className="h-body-2-bold">스크롤</span>해 보세요
+        </span>
+    </Scroll>
+);

--- a/client/src/components/Scroll/index.tsx
+++ b/client/src/components/Scroll/index.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+import { cva } from "class-variance-authority";
+
+export interface ScrollProps {
+    type: "light" | "dark";
+    children: ReactNode;
+}
+
+const scrollTextVariants = cva(``, {
+    variants: {
+        type: {
+            light: "text-n-white",
+            dark: "text-n-neutral-500",
+        },
+    },
+});
+
+export default function Scroll({ type, children }: ScrollProps) {
+    return (
+        <div className="inline-flex flex-col items-center gap-500">
+            <div className={scrollTextVariants({ type })}>{children}</div>
+            <img
+                alt="아래 스크롤 아이콘"
+                src="/assets/icon/arrow-down.svg"
+                className="w-[72px] h-[32px]"
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
## 🖥️ Preview

|light|dark|
|---|---|
|<img width="241" alt="스크린샷 2024-07-25 오후 6 31 27" src="https://github.com/user-attachments/assets/a771fe5f-ecd8-450f-b48d-64f27aa7f678">|<img width="270" alt="스크린샷 2024-07-25 오후 6 31 34" src="https://github.com/user-attachments/assets/e6b0f3af-4c2d-4dd9-9887-fc19d7b67c28">|

close #36

## ✏️ 한 일

- [x] Scroll 컴포넌트 구현


## ❗️ 발생한 이슈 (해결 방안)

### 내부 텍스트 타입

원래는 그냥 텍스트만 받게 하려고 했는데, 문제는 내부 텍스트가 하나의 스타일이 아니라 아래와 같이 weight가 여러 개라서 텍스트만 받기에는 무리가 있다고 판단했다.

<img width="828" alt="스크린샷 2024-07-25 오후 6 34 56" src="https://github.com/user-attachments/assets/c6667b09-ce6b-47bc-bd3e-76c95b87ef0c">
<img width="629" alt="스크린샷 2024-07-25 오후 6 35 50" src="https://github.com/user-attachments/assets/2e6e2096-25f0-4b06-9721-bbb12cb8c5a1">


그래서 부득이하게,,, 사용할 때 텍스트 스타일을 직접 주입해서 사용할 수 있도록 했다.

```tsx
<Scroll {...args} type="dark">
    <span className="h-body-2-regular">
        이벤트에 대해 궁금하다면 <span className="h-body-2-bold">스크롤</span>해 보세요
    </span>
</Scroll>
```


## ❓ 논의가 필요한 사항
