### PR TITLE
[Fix] tooltip position prop를 left, center, right로 제한

### DIFF
--- a/client/src/components/Tooltip/index.stories.tsx
+++ b/client/src/components/Tooltip/index.stories.tsx
@@ -7,7 +7,7 @@ const meta = {
     tags: ["autodocs"],
     argTypes: {
         content: { description: "툴팁 내부에 들어가는 내용", control: "text" },
-        positionPercent: { description: "툴팁 위치 (%)", control: "text" },
+        tooltipPosition: { description: "툴팁 위치" },
         children: { description: "툴팁이 위치할 컴포넌트" },
         isVisible: { description: "툴팁 가시성" },
     },
@@ -19,12 +19,12 @@ const Tooltip = (args: TooltipProps) => {
     return <Component {...args} />;
 };
 
-export const Default = (args: TooltipProps) => (
+export const PositionLeft = (args: TooltipProps) => (
     <div className="absolute left-40 top-40">
         <Tooltip
             {...args}
             isVisible
-            positionPercent="50%"
+            tooltipPosition="left"
             content={
                 <>
                     뱃지 만들고 친구에게 공유하면 당첨 확률 UP!
@@ -38,12 +38,12 @@ export const Default = (args: TooltipProps) => (
     </div>
 );
 
-export const Percent20 = (args: TooltipProps) => (
+export const PositionCenter = (args: TooltipProps) => (
     <div className="absolute left-40 top-40">
         <Tooltip
             {...args}
             isVisible
-            positionPercent="20%"
+            tooltipPosition="center"
             content={
                 <>
                     뱃지 만들고 친구에게 공유하면 당첨 확률 UP!
@@ -57,12 +57,12 @@ export const Percent20 = (args: TooltipProps) => (
     </div>
 );
 
-export const Percent80 = (args: TooltipProps) => (
+export const PositionRight = (args: TooltipProps) => (
     <div className="absolute left-40 top-40">
         <Tooltip
             {...args}
             isVisible
-            positionPercent="80%"
+            tooltipPosition="right"
             content={
                 <>
                     뱃지 만들고 친구에게 공유하면 당첨 확률 UP!

--- a/client/src/components/Tooltip/index.tsx
+++ b/client/src/components/Tooltip/index.tsx
@@ -3,7 +3,7 @@ import { ReactNode, useEffect, useRef, useState } from "react";
 export interface TooltipProps {
     content: ReactNode;
     children: ReactNode;
-    positionPercent?: string;
+    tooltipPosition?: "left" | "center" | "right";
     isVisible: boolean;
 }
 interface PositionType {
@@ -11,12 +11,17 @@ interface PositionType {
     left: number | null;
 }
 
-const TOOLTIP_GAP = 10;
+const TOOLTIP_GAP = 18;
+const TOOLTIP_POSITION_MAP = {
+    left: "10%",
+    center: "50%",
+    right: "90%",
+};
 
 export default function Tooltip({
     content,
     children,
-    positionPercent = "50%",
+    tooltipPosition = "center",
     isVisible,
 }: TooltipProps) {
     const [position, setPosition] = useState<PositionType>({ top: null, left: null });
@@ -29,7 +34,7 @@ export default function Tooltip({
     };
 
     const arrowStyle = {
-        left: positionPercent,
+        left: TOOLTIP_POSITION_MAP[tooltipPosition],
     };
 
     useEffect(() => {
@@ -37,14 +42,19 @@ export default function Tooltip({
             const triggerRect = triggerRef.current.getBoundingClientRect();
             const tooltipRect = tooltipRef.current.getBoundingClientRect();
 
-            const percentToAdditionWidth = (tooltipRect.width * parseInt(positionPercent)) / 100;
+            const leftPosition =
+                tooltipPosition === "left"
+                    ? 0
+                    : tooltipPosition === "center"
+                      ? triggerRect.width / 2 - tooltipRect.width / 2
+                      : triggerRect.width - tooltipRect.width;
 
             setPosition({
                 top: window.scrollY - tooltipRect.height - TOOLTIP_GAP,
-                left: window.scrollX - percentToAdditionWidth + triggerRect.width / 2,
+                left: window.scrollX + leftPosition,
             });
         }
-    }, [isVisible, positionPercent]);
+    }, [isVisible, tooltipPosition]);
 
     return (
         <div className="relative" ref={triggerRef}>


### PR DESCRIPTION
## 🖥️ Preview

<img width="664" alt="스크린샷 2024-07-29 오후 2 24 44" src="https://github.com/user-attachments/assets/bd6a43d9-ffeb-4d55-bcd0-110139851a4b">


close #54

## ✏️ 한 일

- [x] tooltip position prop를 left, center, right로 제한

## ❗️ 발생한 이슈 (해결 방안)

기존에 정의한 tooltip positionPercent props가 실 서비스에서 호환되지 않는 문제가 있어서 position을 left, center, right로 제한해서 호환되게 수정했다.

## ❓ 논의가 필요한 사항
