### PR TITLE
[Fix] CTA Button 기능 추가

### DIFF
--- a/client/src/components/CTAButton/index.stories.tsx
+++ b/client/src/components/CTAButton/index.stories.tsx
@@ -18,8 +18,8 @@ const meta: Meta<typeof Component> = {
             control: { type: "select" },
         },
         url: { description: "이동 경로 url", control: "text" },
-        arrowIcon: { description: "화살표 아이콘 유무", control: "boolean" },
-        shareIcon: { description: "공유 아이콘 유무", control: "boolean" },
+        hasArrowIcon: { description: "화살표 아이콘 유무", control: "boolean" },
+        hasShareIcon: { description: "공유 아이콘 유무", control: "boolean" },
     },
 };
 
@@ -35,15 +35,15 @@ export const EnabledBlue: StoryFn<typeof Component> = (args: CTAButtonProps) => 
         label="더 알아보러 가기"
         color="blue"
         disabled={false}
-        shareIcon={true}
+        hasShareIcon={true}
         url="https://casper.hyundai.com/vehicles/electric/highlight"
     />
 );
 
 export const EnabledWhite: StoryFn<typeof Component> = (args: CTAButtonProps) => (
-    <CTAButton {...args} label="다음" color="white" disabled={false} arrowIcon={true} url="/" />
+    <CTAButton {...args} label="다음" color="white" disabled={false} hasArrowIcon={true} url="/" />
 );
 
 export const Disabled: StoryFn<typeof Component> = (args: CTAButtonProps) => (
-    <CTAButton {...args} label="다음" disabled={true} arrowIcon={true} shareIcon={true} />
+    <CTAButton {...args} label="다음" disabled={true} hasArrowIcon={true} hasShareIcon={true} />
 );

--- a/client/src/components/CTAButton/index.stories.tsx
+++ b/client/src/components/CTAButton/index.stories.tsx
@@ -17,7 +17,8 @@ const meta: Meta<typeof Component> = {
             control: { type: "select" },
         },
         disabled: { description: "버튼 활성 상태", control: "boolean" },
-        hasIcon: { description: "아이콘 유무", control: "boolean" },
+        arrowIcon: { description: "화살표 아이콘 유무", control: "boolean" },
+        shareIcon: { description: "공유 아이콘 유무", control: "boolean" },
     },
 };
 
@@ -28,27 +29,13 @@ const CTAButton: StoryFn<typeof Component> = (args: CTAButtonProps) => {
 };
 
 export const EnabledBlue: StoryFn<typeof Component> = (args: CTAButtonProps) => (
-    <CTAButton
-        {...args}
-        label="이벤트 참여하기"
-        onClick={() => {}}
-        color="blue"
-        disabled={false}
-        hasIcon={true}
-    />
+    <CTAButton {...args} label="이벤트 참여하기" color="blue" disabled={false} shareIcon={true} />
 );
 
 export const EnabledWhite: StoryFn<typeof Component> = (args: CTAButtonProps) => (
-    <CTAButton
-        {...args}
-        label="다음"
-        onClick={() => {}}
-        color="white"
-        disabled={false}
-        hasIcon={true}
-    />
+    <CTAButton {...args} label="다음" color="white" disabled={false} arrowIcon={true} />
 );
 
 export const Disabled: StoryFn<typeof Component> = (args: CTAButtonProps) => (
-    <CTAButton {...args} label="다음" onClick={() => {}} disabled={true} hasIcon={true} />
+    <CTAButton {...args} label="다음" disabled={true} arrowIcon={true} shareIcon={true} />
 );

--- a/client/src/components/CTAButton/index.stories.tsx
+++ b/client/src/components/CTAButton/index.stories.tsx
@@ -11,12 +11,13 @@ const meta: Meta<typeof Component> = {
     argTypes: {
         label: { description: "버튼 텍스트", control: "text" },
         onClick: { description: "버튼 클릭 함수" },
+        disabled: { description: "버튼 활성 상태", control: "boolean" },
         color: {
             description: "버튼 색상",
             options: ["blue", "white"],
             control: { type: "select" },
         },
-        disabled: { description: "버튼 활성 상태", control: "boolean" },
+        url: { description: "이동 경로 url", control: "text" },
         arrowIcon: { description: "화살표 아이콘 유무", control: "boolean" },
         shareIcon: { description: "공유 아이콘 유무", control: "boolean" },
     },
@@ -29,11 +30,18 @@ const CTAButton: StoryFn<typeof Component> = (args: CTAButtonProps) => {
 };
 
 export const EnabledBlue: StoryFn<typeof Component> = (args: CTAButtonProps) => (
-    <CTAButton {...args} label="이벤트 참여하기" color="blue" disabled={false} shareIcon={true} />
+    <CTAButton
+        {...args}
+        label="더 알아보러 가기"
+        color="blue"
+        disabled={false}
+        shareIcon={true}
+        url="https://casper.hyundai.com/vehicles/electric/highlight"
+    />
 );
 
 export const EnabledWhite: StoryFn<typeof Component> = (args: CTAButtonProps) => (
-    <CTAButton {...args} label="다음" color="white" disabled={false} arrowIcon={true} />
+    <CTAButton {...args} label="다음" color="white" disabled={false} arrowIcon={true} url="/" />
 );
 
 export const Disabled: StoryFn<typeof Component> = (args: CTAButtonProps) => (

--- a/client/src/components/CTAButton/index.tsx
+++ b/client/src/components/CTAButton/index.tsx
@@ -1,4 +1,5 @@
 import { VariantProps, cva } from "class-variance-authority";
+import { Link } from "react-router-dom";
 import "@/index.css";
 import ArrowIcon from "/public/assets/icon/arrow.svg?react";
 import ShareIcon from "/public/assets/icon/share.svg?react";
@@ -27,6 +28,7 @@ export interface CTAButtonProps extends VariantProps<typeof buttonVariants> {
     onClick?: () => void;
     disabled?: boolean;
     color?: "blue" | "white";
+    url?: string;
     arrowIcon?: boolean;
     shareIcon?: boolean;
 }
@@ -36,6 +38,7 @@ export default function CTAButton({
     onClick,
     disabled = false,
     color = "blue",
+    url,
     arrowIcon = false,
     shareIcon = false,
 }: CTAButtonProps) {
@@ -46,11 +49,38 @@ export default function CTAButton({
           ? BUTTON_STATUS.ACTIVE_BLUE
           : BUTTON_STATUS.ACTIVE_WHITE;
 
-    return (
-        <button onClick={onClick} disabled={disabled} className={buttonVariants({ status })}>
+    const baseClass = buttonVariants({ status });
+    const linkClass = `${baseClass} inline-flex`;
+
+    const isExternalLink = url && (url.startsWith("http://") || url.startsWith("https://"));
+
+    const content = (
+        <>
             {label}
             {arrowIcon && <ArrowIcon stroke={strokeColor} />}
             {shareIcon && <ShareIcon stroke={strokeColor} />}
-        </button>
+        </>
     );
+
+    if (url && !disabled) {
+        if (isExternalLink) {
+            return (
+                <a href={url} target="_blank" rel="noopener noreferrer" className={linkClass}>
+                    {content}
+                </a>
+            );
+        } else {
+            return (
+                <Link to={url} className={linkClass}>
+                    {content}
+                </Link>
+            );
+        }
+    } else {
+        return (
+            <button onClick={onClick} disabled={disabled} className={baseClass}>
+                {content}
+            </button>
+        );
+    }
 }

--- a/client/src/components/CTAButton/index.tsx
+++ b/client/src/components/CTAButton/index.tsx
@@ -11,7 +11,7 @@ const BUTTON_STATUS = {
 };
 
 const buttonVariants = cva(
-    "h-heading-4-bold rounded-[48px] min-w-60 max-w-[400px] py-3 px-6 h-[60px] cursor-pointer flex justify-center items-center gap-2",
+    "h-heading-4-bold rounded-[48px] min-w-60 max-w-[400px] py-3 px-6 h-[60px] flex justify-center items-center gap-2",
     {
         variants: {
             status: {
@@ -62,25 +62,34 @@ export default function CTAButton({
         </>
     );
 
-    if (url && !disabled) {
-        if (isExternalLink) {
+    const renderButton = () => {
+        if (disabled) {
             return (
-                <a href={url} target="_blank" rel="noopener noreferrer" className={linkClass}>
+                <button disabled className={baseClass}>
                     {content}
-                </a>
-            );
-        } else {
-            return (
-                <Link to={url} className={linkClass}>
-                    {content}
-                </Link>
+                </button>
             );
         }
-    } else {
+
+        if (!url) {
+            return (
+                <button onClick={onClick} className={baseClass}>
+                    {content}
+                </button>
+            );
+        }
+
+        const LinkComponent = isExternalLink ? "a" : Link;
+        const linkProps = isExternalLink
+            ? { href: url, target: "_blank", rel: "noopener noreferrer" }
+            : { to: url };
+
         return (
-            <button onClick={onClick} disabled={disabled} className={baseClass}>
+            <LinkComponent {...linkProps} className={linkClass}>
                 {content}
-            </button>
+            </LinkComponent>
         );
-    }
+    };
+
+    return renderButton();
 }

--- a/client/src/components/CTAButton/index.tsx
+++ b/client/src/components/CTAButton/index.tsx
@@ -24,10 +24,11 @@ const buttonVariants = cva(
 
 export interface CTAButtonProps extends VariantProps<typeof buttonVariants> {
     label: string;
-    onClick: () => void;
+    onClick?: () => void;
     disabled?: boolean;
     color?: "blue" | "white";
-    hasIcon: boolean;
+    arrowIcon?: boolean;
+    shareIcon?: boolean;
 }
 
 export default function CTAButton({
@@ -35,7 +36,8 @@ export default function CTAButton({
     onClick,
     disabled = false,
     color = "blue",
-    hasIcon = false,
+    arrowIcon = false,
+    shareIcon = false,
 }: CTAButtonProps) {
     const strokeColor = disabled ? "#637381" : color === "blue" ? "#FFFFFF" : "#04AAD2";
     const status = disabled
@@ -47,12 +49,8 @@ export default function CTAButton({
     return (
         <button onClick={onClick} disabled={disabled} className={buttonVariants({ status })}>
             {label}
-            {hasIcon && (
-                <>
-                    <ArrowIcon stroke={strokeColor} />
-                    <ShareIcon stroke={strokeColor} />
-                </>
-            )}
+            {arrowIcon && <ArrowIcon stroke={strokeColor} />}
+            {shareIcon && <ShareIcon stroke={strokeColor} />}
         </button>
     );
 }

--- a/client/src/components/CTAButton/index.tsx
+++ b/client/src/components/CTAButton/index.tsx
@@ -29,8 +29,8 @@ export interface CTAButtonProps extends VariantProps<typeof buttonVariants> {
     disabled?: boolean;
     color?: "blue" | "white";
     url?: string;
-    arrowIcon?: boolean;
-    shareIcon?: boolean;
+    hasArrowIcon?: boolean;
+    hasShareIcon?: boolean;
 }
 
 export default function CTAButton({
@@ -39,8 +39,8 @@ export default function CTAButton({
     disabled = false,
     color = "blue",
     url,
-    arrowIcon = false,
-    shareIcon = false,
+    hasArrowIcon = false,
+    hasShareIcon = false,
 }: CTAButtonProps) {
     const strokeColor = disabled ? "#637381" : color === "blue" ? "#FFFFFF" : "#04AAD2";
     const status = disabled
@@ -57,8 +57,8 @@ export default function CTAButton({
     const content = (
         <>
             {label}
-            {arrowIcon && <ArrowIcon stroke={strokeColor} />}
-            {shareIcon && <ShareIcon stroke={strokeColor} />}
+            {hasArrowIcon && <ArrowIcon stroke={strokeColor} />}
+            {hasShareIcon && <ShareIcon stroke={strokeColor} />}
         </>
     );
 

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -1,3 +1,22 @@
+import CTAButton from "@/components/CTAButton";
+
 export default function Main() {
-    return <div>main</div>;
+    return (
+        <div className="flex pt-48">
+            <CTAButton
+                label="외부링크"
+                color="blue"
+                disabled={false}
+                shareIcon={true}
+                url="https://casper.hyundai.com/vehicles/electric/highlight"
+            />
+            <CTAButton
+                label="내부링크"
+                color="blue"
+                disabled={false}
+                shareIcon={true}
+                url="/lottery"
+            />
+        </div>
+    );
 }

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -1,22 +1,3 @@
-import CTAButton from "@/components/CTAButton";
-
 export default function Main() {
-    return (
-        <div className="flex pt-48">
-            <CTAButton
-                label="외부링크"
-                color="blue"
-                disabled={false}
-                shareIcon={true}
-                url="https://casper.hyundai.com/vehicles/electric/highlight"
-            />
-            <CTAButton
-                label="내부링크"
-                color="blue"
-                disabled={false}
-                shareIcon={true}
-                url="/lottery"
-            />
-        </div>
-    );
+    return <></>;
 }


### PR DESCRIPTION
## 🖥️ Preview

https://github.com/user-attachments/assets/36652599-0d89-48f4-9f15-09cf8dd214e9


## ✏️ 한 일
- [x] 아이콘 2개 분리
- [x] 링크 연동 및 내외부 링크 분리
close #15 

## ❗️ 발생한 이슈 (해결 방안)
### ✅ 아이콘 2개 분리

arrowIcon과 shareIcon 두 가지를 따로 사용하기 때문에 hasIcon 대신 두 개의 Props를 분리해주었다.

```tsx
const content = (
    <>
        {label}
        {hasArrowIcon && <ArrowIcon stroke={strokeColor} />}
        {hasShareIcon && <ShareIcon stroke={strokeColor} />}
    </>
);
```

### ✅ 링크 연동 및 내외부 링크 분리

CTA Button 컴포넌트 내부에서 링크를 연동하는 작업을 해주어야 했는데, 문제는 우리 프로젝트 내부에서 라우팅되는 것과 외부 링크와 연동되는 부분을 따로 분리해주어야 했다.

그래서 처음에는 그냥 react-router-dom의 Link 컴포넌트를 사용하여 작업해주었는데, 외부 링크 연동하는 작업에서는 새 창을 열도록 하고 싶었다. 근데 Link 컴포넌트 자체에서는 새 창 열기 기능을 제공해주지 않았다. 그래서 두 가지로 분기 처리를 해주기로 했다. 우선 아래와 같이 props로 받은 url의 접두에 프로토콜 “http” 또는 “https” 이 붙어있는지 확인하도록 해주었다.

```tsx
const isExternalLink = url && (url.startsWith("http://") || url.startsWith("https://"));
```

그래서 만약 isExternalLink가 true일 때는 외부 링크로 접속해야 하므로 a 태그를 사용하여 나머지 target과 rel 속성들을 추가해주었고, 그 외에는 Link 로 라우팅 해주고 LinkComponent를 따로 생성하여 다음과 같이 구현해주었다. 분기 처리된 내부 속성들을 linkProps로 담아서 처리해주었다.

```tsx
const LinkComponent = isExternalLink ? "a" : Link;
const linkProps = isExternalLink
    ? { href: url, target: "_blank", rel: "noopener noreferrer" }
    : { to: url };

return (
    <LinkComponent {...linkProps} className={linkClass}>
        {content}
    </LinkComponent>
);
```

나머지 기존 코드들도 리팩토링 해주었는데, 원래는 그냥 disabled={disabled}라고 해주었다면, 사실 button 컴포넌트에서 disabled는 그냥 작성해주어도 적용되기 때문에, disabled가 true일 때만 button에 disabled 처리 해주고, 다른 하나는 그냥 onClick 함수만 추가해주었다.

```tsx
if (disabled) {
    return (
        <button disabled className={baseClass}>
            {content}
        </button>
    );
}

if (!url) {
    return (
        <button onClick={onClick} className={baseClass}>
            {content}
        </button>
    );
}
```

### ✅ 링크 태그 min-width 적용되지 않는 이슈

추가로 링크 태그 같은 경우에는 width가 제대로 적용이 되지 않는 현상이 있었다. 분명 내부 text가 min-width를 넘지 않는데도 불구하고 그냥 자동으로 max-width가 적용이 되고 있었다. 원래대로라면 min-width 만큼의 너비로 지정되어야 했다.

보아하니, React Router의 Link 컴포넌트와 일반 button 요소의 기본 동작 차이 때문에 발생하는 것이었다. Link 컴포넌트는 내부적으로 a 태그를 사용하기 때문에 인라인 요소의 특성을 가진다. 반면 button은 블록 레벨 요소이기 때문에, 링크가 붙을 때는 inline-flex를 따로 적용시켜주었다.

```tsx
const linkClass = `${baseClass} inline-flex`;
```

## ❓ 논의가 필요한 사항
