### PR TITLE
[Feat] 추첨 페이지 모달 연결

### DIFF
--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import ButtonHeader from "../ButtonHeader";
 import { backgroundBlurVariants, logoVariants } from "./index.style";
 
@@ -9,7 +9,7 @@ export interface HeaderProps {
 
 const EVENT_TYPE = {
     LOTTERY: "lottery",
-    FIRST_COME: "first-come",
+    RUSH: "rush",
 };
 type EventType = (typeof EVENT_TYPE)[keyof typeof EVENT_TYPE];
 
@@ -21,8 +21,8 @@ export default function Header({ type }: HeaderProps) {
         const pathname = location.pathname;
         const selectedEventType = pathname.startsWith(`/${EVENT_TYPE.LOTTERY}`)
             ? EVENT_TYPE.LOTTERY
-            : pathname === "/balance"
-              ? EVENT_TYPE.FIRST_COME
+            : pathname === "/rush"
+              ? EVENT_TYPE.RUSH
               : "";
         setSelectedEvent(selectedEventType);
     }, [location]);
@@ -31,7 +31,9 @@ export default function Header({ type }: HeaderProps) {
         <header className="flex justify-center fixed top-0 w-full h-16 overflow-hidden z-20">
             <div className={backgroundBlurVariants({ type })}></div>
             <div className="w-[1200px] flex justify-between">
-                <h1 className={logoVariants({ type })}>CASPER Electric Event</h1>
+                <Link to="/" className={logoVariants({ type })}>
+                    CASPER Electric Event
+                </Link>
                 <div className="flex gap-700">
                     <ButtonHeader
                         isSelected={selectedEvent === EVENT_TYPE.LOTTERY}
@@ -41,9 +43,9 @@ export default function Header({ type }: HeaderProps) {
                         나만의 캐스퍼 일렉트릭 봇 만들기
                     </ButtonHeader>
                     <ButtonHeader
-                        isSelected={selectedEvent === EVENT_TYPE.FIRST_COME}
+                        isSelected={selectedEvent === EVENT_TYPE.RUSH}
                         type={type}
-                        url="/balance"
+                        url={`/${EVENT_TYPE.RUSH}`}
                     >
                         선착순 밸런스 게임
                     </ButtonHeader>

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import ButtonHeader from "../ButtonHeader";
 import { backgroundBlurVariants, logoVariants } from "./index.style";
 
@@ -9,7 +9,7 @@ export interface HeaderProps {
 
 const EVENT_TYPE = {
     LOTTERY: "lottery",
-    RUSH: "rush",
+    FIRST_COME: "first-come",
 };
 type EventType = (typeof EVENT_TYPE)[keyof typeof EVENT_TYPE];
 
@@ -21,8 +21,8 @@ export default function Header({ type }: HeaderProps) {
         const pathname = location.pathname;
         const selectedEventType = pathname.startsWith(`/${EVENT_TYPE.LOTTERY}`)
             ? EVENT_TYPE.LOTTERY
-            : pathname === "/rush"
-              ? EVENT_TYPE.RUSH
+            : pathname === "/balance"
+              ? EVENT_TYPE.FIRST_COME
               : "";
         setSelectedEvent(selectedEventType);
     }, [location]);
@@ -31,9 +31,7 @@ export default function Header({ type }: HeaderProps) {
         <header className="flex justify-center fixed top-0 w-full h-16 overflow-hidden z-20">
             <div className={backgroundBlurVariants({ type })}></div>
             <div className="w-[1200px] flex justify-between">
-                <Link to="/" className={logoVariants({ type })}>
-                    CASPER Electric Event
-                </Link>
+                <h1 className={logoVariants({ type })}>CASPER Electric Event</h1>
                 <div className="flex gap-700">
                     <ButtonHeader
                         isSelected={selectedEvent === EVENT_TYPE.LOTTERY}
@@ -43,9 +41,9 @@ export default function Header({ type }: HeaderProps) {
                         나만의 캐스퍼 일렉트릭 봇 만들기
                     </ButtonHeader>
                     <ButtonHeader
-                        isSelected={selectedEvent === EVENT_TYPE.RUSH}
+                        isSelected={selectedEvent === EVENT_TYPE.FIRST_COME}
                         type={type}
-                        url={`/${EVENT_TYPE.RUSH}`}
+                        url="/balance"
                     >
                         선착순 밸런스 게임
                     </ButtonHeader>

--- a/client/src/components/Input/index.tsx
+++ b/client/src/components/Input/index.tsx
@@ -45,8 +45,8 @@ export default function Input({
             />
             {!isFocused && value.length === 0 && (
                 <div className="absolute left-600 top-[11px] text-n-neutral-500">
-                    <p className="h-detail-1-regular">{label}</p>
-                    <p className="h-body-1-regular">{placeholder}</p>
+                    <p className="block h-detail-1-regular">{label}</p>
+                    <p className="block h-body-1-regular">{placeholder}</p>
                 </div>
             )}
         </label>

--- a/client/src/components/PopUp/index.tsx
+++ b/client/src/components/PopUp/index.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { PHONE_NUMBER_FORMAT, formatPhoneNumber } from "@/utils/formatPhoneNumber";
 import CTAButton from "../CTAButton";
 import CheckBox from "../CheckBox";
@@ -37,18 +37,14 @@ export default function PopUp({
         handlePhoneNumberChange(formattedPhoneNumber);
     };
 
-    const handleDimClick = () => {
-        handleClose();
-    };
-
     return (
-        <div className="fixed w-full h-full left-0 top-0 z-50">
+        <div className="fixed w-full h-full left-0 top-0 z-20">
             <div
                 className="absolute left-0 top-0 w-[100%] h-[100%] bg-n-black/[.4]"
-                onClick={handleDimClick}
+                onClick={handleClose}
             />
             <div className="px-[80px] py-[81px] bg-n-white rounded-800 absolute left-[50%] top-[50%] translate-y-[-50%] translate-x-[-50%]">
-                <button className="absolute right-700 top-700">
+                <button className="absolute right-700 top-700" onClick={handleClose}>
                     <img alt="팝업 닫기 버튼" src="/assets/icons/close.svg" />
                 </button>
 

--- a/client/src/components/PopUp/index.tsx
+++ b/client/src/components/PopUp/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { MouseEvent, useEffect, useState } from "react";
 import { PHONE_NUMBER_FORMAT, formatPhoneNumber } from "@/utils/formatPhoneNumber";
 import CTAButton from "../CTAButton";
 import CheckBox from "../CheckBox";
@@ -8,14 +8,14 @@ export interface PopUpProps {
     phoneNumber: string;
     handlePhoneNumberChange: (val: string) => void;
     handleClose: () => void;
-    handleConfirm: () => void;
+    confirmUrl: string;
 }
 
 export default function PopUp({
     phoneNumber = "",
     handlePhoneNumberChange,
     handleClose,
-    handleConfirm,
+    confirmUrl,
 }: PopUpProps) {
     const [isUserInfoCheck, setIsUserInfoCheck] = useState(true);
     const [isMarketingInfoCheck, setIsMarketingInfoCheck] = useState(true);
@@ -41,17 +41,12 @@ export default function PopUp({
         handleClose();
     };
 
-    const handleCTAButtonClick = () => {
-        if (canConfirm) {
-            handleConfirm();
-        }
-    };
-
     return (
-        <div
-            className="fixed left-0 top-0 w-full h-full z-50 bg-n-black/[.4]"
-            onClick={handleDimClick}
-        >
+        <div className="fixed w-full h-full left-0 top-0 z-50">
+            <div
+                className="absolute left-0 top-0 w-[100%] h-[100%] bg-n-black/[.4]"
+                onClick={handleDimClick}
+            />
             <div className="px-[80px] py-[81px] bg-n-white rounded-800 absolute left-[50%] top-[50%] translate-y-[-50%] translate-x-[-50%]">
                 <button className="absolute right-700 top-700">
                     <img alt="팝업 닫기 버튼" src="/assets/icons/close.svg" />
@@ -105,7 +100,7 @@ export default function PopUp({
                         disabled={canConfirm ? false : true}
                         color="blue"
                         label="다음"
-                        onClick={handleCTAButtonClick}
+                        url={confirmUrl}
                     />
                 </div>
             </div>

--- a/client/src/components/Toast/index.tsx
+++ b/client/src/components/Toast/index.tsx
@@ -6,7 +6,7 @@ interface ToastProps {
 export default function Toast({ message, isVisible }: ToastProps) {
     return (
         <div
-            className={`fixed bottom-4 right-4 h-heading-4-bold bg-s-blue text-n-white px-6 py-4 rounded-500 transition-opacity ${
+            className={`fixed top-[88px] left-[50%] translate-x-[-50%] h-heading-4-bold bg-s-blue text-n-white px-6 py-4 rounded-500 transition-opacity ${
                 isVisible ? "opacity-100" : "opacity-0"
             }`}
         >

--- a/client/src/features/Lottery/Headline.tsx
+++ b/client/src/features/Lottery/Headline.tsx
@@ -1,7 +1,11 @@
 import CTAButton from "@/components/CTAButton";
 import Scroll from "@/components/Scroll";
 
-export default function Headline() {
+interface HeadlineProps {
+    handleClickShortCutButton: () => void;
+}
+
+export default function Headline({ handleClickShortCutButton }: HeadlineProps) {
     return (
         <section className="h-screen bg-[url('/assets/lottery/electric-line.webp')] bg-no-repeat bg-cover w-full relative flex flex-col items-center justify-center">
             <div className="absolute pointer-events-none">
@@ -26,7 +30,7 @@ export default function Headline() {
                 <CTAButton
                     label="캐스퍼 일렉트릭 봇 만들러 가기"
                     hasArrowIcon
-                    url="/lottery/custom"
+                    onClick={handleClickShortCutButton}
                 />
             </div>
 

--- a/client/src/features/Lottery/ShortCut.tsx
+++ b/client/src/features/Lottery/ShortCut.tsx
@@ -1,6 +1,10 @@
 import CTAButton from "@/components/CTAButton";
 
-export default function ShortCut() {
+interface ShortCutProps {
+    handleClickShortCutButton: () => void;
+}
+
+export default function ShortCut({ handleClickShortCutButton }: ShortCutProps) {
     return (
         <div className="h-[623px] bg-n-black flex flex-col justify-center items-center text-center">
             <img
@@ -15,7 +19,11 @@ export default function ShortCut() {
                 캐스퍼 일렉트릭부터 스타벅스 기프티콘까지 선물이 가득!
             </h3>
             <div className="h-[30px]" />
-            <CTAButton label="캐스퍼 일렉트릭 봇 만들러 가기" hasArrowIcon url="/lottery/custom" />
+            <CTAButton
+                label="캐스퍼 일렉트릭 봇 만들러 가기"
+                hasArrowIcon
+                onClick={handleClickShortCutButton}
+            />
         </div>
     );
 }

--- a/client/src/hooks/usePopup.tsx
+++ b/client/src/hooks/usePopup.tsx
@@ -19,11 +19,16 @@ export default function usePopup({
         setIsVisible(true);
     };
 
+    const handleClosePopup = () => {
+        handlePhoneNumberChange("");
+        setIsVisible(false);
+    };
+
     const PopupComponent = isVisible ? (
         <Popup
             phoneNumber={phoneNumber}
             handlePhoneNumberChange={handlePhoneNumberChange}
-            handleClose={() => setIsVisible(false)}
+            handleClose={handleClosePopup}
             confirmUrl={confirmUrl}
         />
     ) : (

--- a/client/src/hooks/usePopup.tsx
+++ b/client/src/hooks/usePopup.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+import Popup, { PopUpProps } from "@/components/PopUp";
+
+export default function usePopup({
+    phoneNumber,
+    handlePhoneNumberChange,
+    confirmUrl,
+}: Omit<PopUpProps, "handleClose">) {
+    const [isVisible, setIsVisible] = useState(false);
+
+    const handleOpenPopup = () => {
+        setIsVisible(true);
+    };
+
+    const PopupComponent = isVisible ? (
+        <Popup
+            phoneNumber={phoneNumber}
+            handlePhoneNumberChange={handlePhoneNumberChange}
+            handleClose={() => setIsVisible(false)}
+            confirmUrl={confirmUrl}
+        />
+    ) : (
+        <></>
+    );
+
+    return { handleOpenPopup, PopupComponent };
+}

--- a/client/src/hooks/usePopup.tsx
+++ b/client/src/hooks/usePopup.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Popup, { PopUpProps } from "@/components/PopUp";
 
 export default function usePopup({
@@ -8,7 +8,14 @@ export default function usePopup({
 }: Omit<PopUpProps, "handleClose">) {
     const [isVisible, setIsVisible] = useState(false);
 
+    useEffect(() => {
+        if (!isVisible) {
+            document.body.style.overflow = "unset";
+        }
+    }, [isVisible]);
+
     const handleOpenPopup = () => {
+        document.body.style.overflow = "hidden";
         setIsVisible(true);
     };
 

--- a/client/src/pages/Lottery/index.tsx
+++ b/client/src/pages/Lottery/index.tsx
@@ -12,6 +12,7 @@ import SmileBadge from "@/features/Lottery/SmileBadge";
 import WheelDesign from "@/features/Lottery/WheelDesign";
 import usePopup from "@/hooks/usePopup";
 import useScrollTop from "@/hooks/useScrollTop";
+import useToast from "@/hooks/useToast";
 
 export default function Lottery() {
     useScrollTop();
@@ -27,9 +28,19 @@ export default function Lottery() {
         handlePhoneNumberChange,
         confirmUrl: `/lottery/custom`,
     });
+    const { showToast, ToastComponent } = useToast("이벤트 기간이 아닙니다");
+
+    /**
+     * TODO: 이벤트 기간 맞는지 확인하는 로직 필요
+     */
+    const isEventPeriod = false;
 
     const handleClickShortCut = () => {
-        handleOpenPopup();
+        if (isEventPeriod) {
+            handleOpenPopup();
+        } else {
+            showToast();
+        }
     };
 
     return (
@@ -48,6 +59,7 @@ export default function Lottery() {
             <Footer />
 
             {PopupComponent}
+            {ToastComponent}
         </div>
     );
 }

--- a/client/src/pages/Lottery/index.tsx
+++ b/client/src/pages/Lottery/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Footer from "@/components/Footer";
 import Notice from "@/components/Notice";
 import CustomDesign from "@/features/Lottery/CustomDesign";
@@ -9,14 +10,31 @@ import PixelDesign from "@/features/Lottery/PixelDesign";
 import ShortCut from "@/features/Lottery/ShortCut";
 import SmileBadge from "@/features/Lottery/SmileBadge";
 import WheelDesign from "@/features/Lottery/WheelDesign";
+import usePopup from "@/hooks/usePopup";
 import useScrollTop from "@/hooks/useScrollTop";
 
 export default function Lottery() {
     useScrollTop();
 
+    const [phoneNumber, setPhoneNumber] = useState<string>("");
+
+    const handlePhoneNumberChange = (val: string) => {
+        setPhoneNumber(val);
+    };
+
+    const { handleOpenPopup, PopupComponent } = usePopup({
+        phoneNumber,
+        handlePhoneNumberChange,
+        confirmUrl: `/lottery/custom`,
+    });
+
+    const handleClickShortCut = () => {
+        handleOpenPopup();
+    };
+
     return (
         <div className="overflow-x-hidden">
-            <Headline />
+            <Headline handleClickShortCutButton={handleClickShortCut} />
             <Intro />
             <HeadLamp />
             <PixelDesign />
@@ -24,10 +42,12 @@ export default function Lottery() {
             <CustomDesign />
             <NewColor />
             <SmileBadge />
-            <ShortCut />
+            <ShortCut handleClickShortCutButton={handleClickShortCut} />
 
             <Notice />
             <Footer />
+
+            {PopupComponent}
         </div>
     );
 }

--- a/client/src/pages/Lottery/index.tsx
+++ b/client/src/pages/Lottery/index.tsx
@@ -33,7 +33,7 @@ export default function Lottery() {
     /**
      * TODO: 이벤트 기간 맞는지 확인하는 로직 필요
      */
-    const isEventPeriod = false;
+    const isEventPeriod = true;
 
     const handleClickShortCut = () => {
         if (isEventPeriod) {


### PR DESCRIPTION
## 🖥️ Preview



https://github.com/user-attachments/assets/bb82674d-a87e-4c4e-9d28-74c084446ea1


https://github.com/user-attachments/assets/9e1ce2ae-f2d7-443d-9b80-a96558827fd2


close #72 


## ✏️ 한 일

- [x] 추첨 페이지에서 이벤트 참여하기 버튼 누르면 모달(팝업)로 연결

## ❗️ 발생한 이슈 (해결 방안)

### popup이 떠있을 때 뒷배경이 스크롤되는 문제

처음에는 `overflow: hidden`를 모달 영역에 줘서 스크롤 방지가 안 되는 문제가 있었다. 팝업이 떠 있을 때 스크롤 방지를 하려면 body 자체에 스크롤 방지 옵션을 넣어줘야 제대로 스크롤 방지가 된다. ㅎ

```tsx
    const handleClosePopup = () => {
        document.body.style.overflow = "unset";
        setIsVisible(false);
    };

    const handleOpenPopup = () => {
        document.body.style.overflow = "hidden";
        setIsVisible(true);
    };
```

그래서 처음에 요렇게 해줬는데, 문제가 있었다. close 로직은 dim 영역을 클릭하게나 X 버튼을 클릭했을때만 호출되는 로직이라 제대로 제출해서 confirm을 호출했을 때는 overflow hidden이 그대로 남아있어서 스크롤이 막히는 게 문제였다.


```tsx
    useEffect(() => {
        if (!isVisible) {
            document.body.style.overflow = "unset";
        }
    }, [isVisible]);

    const handleOpenPopup = () => {
        document.body.style.overflow = "hidden";
        setIsVisible(true);
    };
```

그래서 visible이 바뀔 때마다 값을 체크해서 false면 overflow가 해제되도록 수정했다.

## ❓ 논의가 필요한 사항

