### PR TITLE
[Fix] 툴팁 위치 오류 수정

### DIFF
--- a/client/src/components/Tooltip/index.tsx
+++ b/client/src/components/Tooltip/index.tsx
@@ -62,8 +62,8 @@ export default function Tooltip({
         const leftPosition = getLeftPosition(tooltipPosition, triggerRect.width, tooltipRect.width);
 
         setPosition({
-            top: window.scrollY - tooltipRect.height - TOOLTIP_GAP,
-            left: window.scrollX + leftPosition,
+            top: triggerRef.current.scrollTop - tooltipRect.height - TOOLTIP_GAP,
+            left: triggerRef.current.scrollLeft + leftPosition,
         });
     }, [isVisible, tooltipPosition]);
 


### PR DESCRIPTION
## 🖥️ Preview

https://github.com/user-attachments/assets/cffb8574-2d1a-4103-b3e4-c2b75955359e




close #87

## ✏️ 한 일

- [x] 툴팁 위치 오류 수정

## ❗️ 발생한 이슈 (해결 방안)

기존에 툴팁이 위치를 제대로 못 잡는 문제가 있었는데, 스크롤의 기준을 `window.scrollY`, `window.scrollX`로 잡다보니까 문서 전체의 렌더링이 완벽하게 되지 않은 시점에서 윈도우 scroll이 계산되면서 발생하는 문제 같았습니다.

그래서 window 기준 스크롤에서 트리거 기준 scroll을 계산하는 걸로 바꾸었습니다. (triggerRef.current.scrollLeft와 triggerRef.current.scrollTop은 요소의 스크롤을 직접 참조해서 정확히 스크롤 위치 가져옴)

## ❓ 논의가 필요한 사항
