### PR TITLE
[Fix] 캐스퍼 쇼케이스 화면 로딩 오래 걸리는 오류 수정

### DIFF
--- a/client/src/features/CasperCustom/CasperFlipCard.tsx
+++ b/client/src/features/CasperCustom/CasperFlipCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { motion } from "framer-motion";
 import { CASPER_CARD_SIZE, CASPER_SIZE_OPTION } from "@/constants/CasperCustom/casper";
 import { CasperCardType } from "../CasperShowCase/TransitionCasperCards";
@@ -10,7 +11,7 @@ interface CasperFlipCardProps {
     isFlipped: boolean;
 }
 
-export default function CasperFlipCard({ size, card, isFlipped }: CasperFlipCardProps) {
+function CasperFlipCard({ size, card, isFlipped }: CasperFlipCardProps) {
     return (
         <div style={{ perspective: "1000px" }}>
             <motion.div
@@ -54,3 +55,5 @@ export default function CasperFlipCard({ size, card, isFlipped }: CasperFlipCard
         </div>
     );
 }
+
+export default memo(CasperFlipCard);

--- a/client/src/features/CasperShowCase/TransitionCasperCards.tsx
+++ b/client/src/features/CasperShowCase/TransitionCasperCards.tsx
@@ -28,7 +28,7 @@ export default function TransitionCasperCards({
     gap,
     isEndCard,
 }: TransitionCasperCardsProps) {
-    const containerRef = useRef<HTMLDivElement>(null);
+    const containerRef = useRef<HTMLUListElement>(null);
     const transitionControls = useAnimation();
 
     const [x, setX] = useState<number>(initialX);
@@ -67,18 +67,18 @@ export default function TransitionCasperCards({
         };
 
         return (
-            <div key={id} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+            <li key={id} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
                 <CasperFlipCard
                     card={cardItem}
                     size={CASPER_SIZE_OPTION.SM}
                     isFlipped={isFlipped}
                 />
-            </div>
+            </li>
         );
     };
 
     return (
-        <motion.div
+        <motion.ul
             ref={containerRef}
             className="flex"
             animate={transitionControls}
@@ -91,6 +91,6 @@ export default function TransitionCasperCards({
         >
             {cardList.map((card) => renderCardItem(card, card.id))}
             {cardList.map((card) => renderCardItem(card, `${card.id}-clone`))}
-        </motion.div>
+        </motion.ul>
     );
 }

--- a/client/src/features/CasperShowCase/TransitionCasperCards.tsx
+++ b/client/src/features/CasperShowCase/TransitionCasperCards.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { motion, useAnimation } from "framer-motion";
-import { CASPER_SIZE_OPTION } from "@/constants/CasperCustom/casper";
+import { CASPER_CARD_SIZE, CASPER_SIZE_OPTION } from "@/constants/CasperCustom/casper";
 import { CARD_TRANSITION } from "@/constants/CasperShowCase/showCase";
+import useLazyLoading from "@/hooks/useLazyLoading";
 import { SelectedCasperIdxType } from "@/types/casperCustom";
 import CasperFlipCard from "../CasperCustom/CasperFlipCard";
 
@@ -55,6 +56,7 @@ export default function TransitionCasperCards({
 
     const renderCardItem = (cardItem: CasperCardType, id: string) => {
         const [isFlipped, setIsFlipped] = useState<boolean>(false);
+        const { isInView, cardRef } = useLazyLoading<HTMLLIElement>();
 
         const handleMouseEnter = () => {
             stopAnimation();
@@ -67,12 +69,23 @@ export default function TransitionCasperCards({
         };
 
         return (
-            <li key={id} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-                <CasperFlipCard
-                    card={cardItem}
-                    size={CASPER_SIZE_OPTION.SM}
-                    isFlipped={isFlipped}
-                />
+            <li
+                ref={cardRef}
+                key={id}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+                style={{
+                    width: CASPER_CARD_SIZE[CASPER_SIZE_OPTION.SM].CARD_WIDTH,
+                    height: CASPER_CARD_SIZE[CASPER_SIZE_OPTION.SM].CARD_HEIGHT,
+                }}
+            >
+                {isInView && (
+                    <CasperFlipCard
+                        card={cardItem}
+                        size={CASPER_SIZE_OPTION.SM}
+                        isFlipped={isFlipped}
+                    />
+                )}
             </li>
         );
     };

--- a/client/src/hooks/useLazyLoading.ts
+++ b/client/src/hooks/useLazyLoading.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from "react";
+
+export default function useLazyLoading() {
+    const [isInView, setIsInView] = useState<boolean>(false);
+    const cardRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    setIsInView(true);
+                    observer.disconnect();
+                }
+            },
+            { threshold: 0.1, root: document.body }
+        );
+
+        if (cardRef.current) {
+            observer.observe(cardRef.current);
+        }
+
+        return () => {
+            if (cardRef.current) {
+                observer.unobserve(cardRef.current);
+            }
+        };
+    }, [cardRef]);
+
+    return { isInView, cardRef };
+}

--- a/client/src/hooks/useLazyLoading.ts
+++ b/client/src/hooks/useLazyLoading.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 
-export default function useLazyLoading() {
+export default function useLazyLoading<T extends HTMLElement>() {
     const [isInView, setIsInView] = useState<boolean>(false);
-    const cardRef = useRef<HTMLDivElement>(null);
+    const cardRef = useRef<T>(null);
 
     useEffect(() => {
         const observer = new IntersectionObserver(
@@ -12,7 +12,7 @@ export default function useLazyLoading() {
                     observer.disconnect();
                 }
             },
-            { threshold: 0.1, root: document.body }
+            { threshold: 0, root: document.body }
         );
 
         if (cardRef.current) {


### PR DESCRIPTION
## 🖥️ Preview


https://github.com/user-attachments/assets/b6c12340-f965-4d61-a30e-7da7f4dceb08



close #95

## ✏️ 한 일

- [x] CasperFlipCard 불필요한 리렌더링 제거
- [x] lazy loading 사용해서 화면에 보이는 컴포넌트만 렌더링되게 수정

## ❗️ 발생한 이슈 (해결 방안)

### 애니메이션 시 불필요한 리렌더링 발생으로 버벅이는 현상

https://github.com/user-attachments/assets/7fbd1e54-56b4-4050-90fa-c12b194ef02c

카드에 hover가 될 때마다 카드에 flip 애니메이션이 발생해야하는데, 이때 관련 없는 다른 컴포넌트들에도 리렌더링이 발생하면서 flip 애니메이션이 버벅이는 현상이 있었다.

문제는 리스트를 뿌려주는 컴포넌트에서 hover 된 시점의 x를 저장하고 업데이트 하는 로직을 담당하고 있는데, 그렇다 보니 hover 될 때마다 상태가 바뀌게 되었고, 자식 컴포넌트인 CasperFlipCard 컴포넌트의 리렌더링도 발생한 것이다.

```tsx
function CasperFlipCard({ size, card, isFlipped }: CasperFlipCardProps) {
  ...
}

export default memo(CasperFlipCard);
```

react에서 제공하는 `memo`를 사용해서 props가 변할 때만 리렌더링이 발생하게 수정했다.

https://github.com/user-attachments/assets/94bc74b8-7da0-492d-aa08-2ab6c4968967


### 초기 렌더링 시 너무 많은 컴포넌트를 렌더링하는 문제

https://github.com/user-attachments/assets/45763c51-cec0-4d8d-adfe-fdddb0bba910

showcase 화면으로 넘어갈때 시간이 너무 많이 걸리는 문제가 있었다. 살펴보니 컴포넌트 목록이 100개가 되면서 한 번에 너무 많은 컴포넌트를 렌더링하면서 생기는 문제였다. 

```
navigate 버튼 클릭 1722847626460
showcase load 완료 1722847627011
=> 551
```

시간을 계산해보니 약 0.6 초가 걸렸다.

문제를 해결하기 위해서 처음에 모든 컴포넌트를 렌더링하지 않고 화면에 보일 때만 렌더링 하게 하기 위해서 `IntersectionObserver`를 활용했다. viewport와 DOM의 변화를 감지해서 DOM이 보여야하는 위치에 다다랐을 때 렌더링을 할 수 있도록 해줬다.

https://github.com/user-attachments/assets/0e3d69e6-725b-4141-b611-6fb78ac31a1b


```
navigate 버튼 클릭 1722847591698
showcase load 완료 1722847591728
=> 30
```

초기 로딩 시간이 0.03초로 시간이 줄어들었다.


## ❓ 논의가 필요한 사항
