### PR TITLE
[Refactor] Import 구문 정리

### DIFF
--- a/client/src/features/CasperCustom/Battery.tsx
+++ b/client/src/features/CasperCustom/Battery.tsx
@@ -8,7 +8,7 @@ interface BatteryProps {
     applyCount: number;
 }
 
-export default function Battery({ applyCount }: BatteryProps) {
+export function Battery({ applyCount }: BatteryProps) {
     const [batteryApplyArray, setBatteryApplyArray] = useState<boolean[]>(batteryArray);
 
     useEffect(() => {

--- a/client/src/features/CasperCustom/CasperCardBackUI.tsx
+++ b/client/src/features/CasperCustom/CasperCardBackUI.tsx
@@ -60,7 +60,7 @@ const INNER_STYLE = {
     },
 };
 
-export default function CasperCardBackUI({
+export function CasperCardBackUI({
     size = CASPER_SIZE_OPTION.LG,
     casperName,
     expectations,

--- a/client/src/features/CasperCustom/CasperCardFrontUI.tsx
+++ b/client/src/features/CasperCustom/CasperCardFrontUI.tsx
@@ -45,7 +45,7 @@ const casperNameVariants = cva(
     }
 );
 
-export default function CasperCardFrontUI({
+export function CasperCardFrontUI({
     size = CASPER_SIZE_OPTION.LG,
     optionDescription,
     casperName,

--- a/client/src/features/CasperCustom/CasperCustomFinish.tsx
+++ b/client/src/features/CasperCustom/CasperCustomFinish.tsx
@@ -8,15 +8,15 @@ import useCasperCustomDispatchContext from "@/hooks/useCasperCustomDispatchConte
 import useCasperCustomStateContext from "@/hooks/useCasperCustomStateContext";
 import { CASPER_ACTION } from "@/types/casperCustom";
 import { saveDomImage } from "@/utils/saveDomImage";
-import Battery from "./Battery";
-import MyCasperCardFront from "./MyCasperCardFront";
+import { Battery } from "./Battery";
+import { MyCasperCardFront } from "./MyCasperCardFront";
 import ArrowIcon from "/public/assets/icons/arrow.svg?react";
 
 interface CasperCustomFinishProps {
     handleResetStep: () => void;
 }
 
-export default function CasperCustomFinish({ handleResetStep }: CasperCustomFinishProps) {
+export function CasperCustomFinish({ handleResetStep }: CasperCustomFinishProps) {
     const dispatch = useCasperCustomDispatchContext();
     const { casperName } = useCasperCustomStateContext();
 

--- a/client/src/features/CasperCustom/CasperCustomFinishing.tsx
+++ b/client/src/features/CasperCustom/CasperCustomFinishing.tsx
@@ -4,13 +4,13 @@ import { CASPER_SIZE_OPTION } from "@/constants/CasperCustom/casper";
 import { DISSOLVE } from "@/constants/animation";
 import useCasperCustomStateContext from "@/hooks/useCasperCustomStateContext";
 import { CasperCardType } from "../CasperShowCase/TransitionCasperCards";
-import CasperFlipCard from "./CasperFlipCard";
+import { CasperFlipCard } from "./CasperFlipCard";
 
 interface CasperCustomFinishingProps {
     navigateNextStep: () => void;
 }
 
-export default function CasperCustomFinishing({ navigateNextStep }: CasperCustomFinishingProps) {
+export function CasperCustomFinishing({ navigateNextStep }: CasperCustomFinishingProps) {
     const { casperName, expectations, selectedCasperIdx } = useCasperCustomStateContext();
     const [isFlipped, setIsFlipped] = useState<boolean>(false);
 

--- a/client/src/features/CasperCustom/CasperCustomForm.tsx
+++ b/client/src/features/CasperCustom/CasperCustomForm.tsx
@@ -5,13 +5,13 @@ import { DISSOLVE } from "@/constants/animation";
 import useCasperCustomDispatchContext from "@/hooks/useCasperCustomDispatchContext";
 import useCasperCustomStateContext from "@/hooks/useCasperCustomStateContext";
 import { CASPER_ACTION } from "@/types/casperCustom";
-import MyCasperCardFront from "./MyCasperCardFront";
+import { MyCasperCardFront } from "./MyCasperCardFront";
 
 interface CasperCustomFormProps {
     handleSubmitCustomCasper: () => void;
 }
 
-export default function CasperCustomForm({ handleSubmitCustomCasper }: CasperCustomFormProps) {
+export function CasperCustomForm({ handleSubmitCustomCasper }: CasperCustomFormProps) {
     const { casperName, expectations } = useCasperCustomStateContext();
     const dispatch = useCasperCustomDispatchContext();
 

--- a/client/src/features/CasperCustom/CasperCustomPanel.tsx
+++ b/client/src/features/CasperCustom/CasperCustomPanel.tsx
@@ -4,9 +4,9 @@ import { CASPER_OPTION, CUSTOM_OPTION, OPTION_TYPE } from "@/constants/CasperCus
 import useCasperCustomDispatchContext from "@/hooks/useCasperCustomDispatchContext";
 import useCasperCustomStateContext from "@/hooks/useCasperCustomStateContext";
 import { CASPER_ACTION } from "@/types/casperCustom";
-import CustomOptionImageItem from "./CustomOptionImageItem";
-import EyesPanelComponent from "./EyesPanel";
-import SharedPanel from "./SharedPanel";
+import { CustomOptionImageItem } from "./CustomOptionImageItem";
+import { EyesPanel as EyesPanelComponent } from "./EyesPanel";
+import { SharedPanel } from "./SharedPanel";
 
 interface GetCustomOptionImageItemProps {
     optionId: string;

--- a/client/src/features/CasperCustom/CasperCustomPanelLayout.tsx
+++ b/client/src/features/CasperCustom/CasperCustomPanelLayout.tsx
@@ -4,10 +4,7 @@ interface CasperCustomPanelLayoutProps extends PropsWithChildren {
     className?: string;
 }
 
-export default function CasperCustomPanelLayout({
-    children,
-    className,
-}: CasperCustomPanelLayoutProps) {
+export function CasperCustomPanelLayout({ children, className }: CasperCustomPanelLayoutProps) {
     return (
         <div className={`w-[724px] h-[500px] bg-n-neutral-950 rounded-800 ${className}`}>
             {children}

--- a/client/src/features/CasperCustom/CasperCustomProcess.tsx
+++ b/client/src/features/CasperCustom/CasperCustomProcess.tsx
@@ -4,7 +4,7 @@ import CTAButton from "@/components/CTAButton";
 import ListStep from "@/components/ListStep";
 import { CUSTOM_OPTION_ARRAY } from "@/constants/CasperCustom/customStep";
 import { DISSOLVE } from "@/constants/animation";
-import MyCasperCardFront from "@/features/CasperCustom/MyCasperCardFront";
+import { MyCasperCardFront } from "@/features/CasperCustom/MyCasperCardFront";
 import useCasperCustomStateContext from "@/hooks/useCasperCustomStateContext";
 import { getCasperOptionDescription } from "@/utils/CasperCustom/getCasperOptionDescription";
 
@@ -12,7 +12,7 @@ interface CasperCustomProcessProps {
     handleClickNextStep: () => void;
 }
 
-export default function CasperCustomProcess({ handleClickNextStep }: CasperCustomProcessProps) {
+export function CasperCustomProcess({ handleClickNextStep }: CasperCustomProcessProps) {
     const { selectedCasperIdx } = useCasperCustomStateContext();
     const [selectedStepIdx, setSelectedStepIdx] = useState<number>(0);
 

--- a/client/src/features/CasperCustom/CasperFlipCard.tsx
+++ b/client/src/features/CasperCustom/CasperFlipCard.tsx
@@ -2,8 +2,8 @@ import { memo } from "react";
 import { motion } from "framer-motion";
 import { CASPER_CARD_SIZE, CASPER_SIZE_OPTION } from "@/constants/CasperCustom/casper";
 import { CasperCardType } from "../CasperShowCase/TransitionCasperCards";
-import CasperCardBackUI from "./CasperCardBackUI";
-import CasperCardFrontUI from "./CasperCardFrontUI";
+import { CasperCardBackUI } from "./CasperCardBackUI";
+import { CasperCardFrontUI } from "./CasperCardFrontUI";
 
 interface CasperFlipCardProps {
     size: (typeof CASPER_SIZE_OPTION)[keyof typeof CASPER_SIZE_OPTION];
@@ -56,4 +56,5 @@ function CasperFlipCard({ size, card, isFlipped }: CasperFlipCardProps) {
     );
 }
 
-export default memo(CasperFlipCard);
+const MemoizedCasperFlipCard = memo(CasperFlipCard);
+export { MemoizedCasperFlipCard as CasperFlipCard };

--- a/client/src/features/CasperCustom/CustomOptionImageItem.tsx
+++ b/client/src/features/CasperCustom/CustomOptionImageItem.tsx
@@ -18,7 +18,7 @@ const selectableVariants = cva(
     }
 );
 
-export default function CustomOptionImageItem({
+export function CustomOptionImageItem({
     optionId,
     selected,
     handleClickOption,

--- a/client/src/features/CasperCustom/EyesOptionImageItem.tsx
+++ b/client/src/features/CasperCustom/EyesOptionImageItem.tsx
@@ -15,7 +15,7 @@ const selectableImageVariants = cva(`rounded-1000 border-[2px] cursor-pointer`, 
     },
 });
 
-export default function EyesOptionImageItem({
+export function EyesOptionImageItem({
     isSelected,
     handleClickOption,
     previewUrl,

--- a/client/src/features/CasperCustom/EyesPanel.tsx
+++ b/client/src/features/CasperCustom/EyesPanel.tsx
@@ -8,10 +8,10 @@ import {
 import useCasperCustomDispatchContext from "@/hooks/useCasperCustomDispatchContext";
 import useCasperCustomStateContext from "@/hooks/useCasperCustomStateContext";
 import { CASPER_ACTION } from "@/types/casperCustom";
-import CasperCustomPanelLayout from "./CasperCustomPanelLayout";
-import EyesOptionImageItem from "./EyesOptionImageItem";
+import { CasperCustomPanelLayout } from "./CasperCustomPanelLayout";
+import { EyesOptionImageItem } from "./EyesOptionImageItem";
 
-export default function EyesPanel() {
+export function EyesPanel() {
     const { selectedCasperIdx } = useCasperCustomStateContext();
     const dispatch = useCasperCustomDispatchContext();
 

--- a/client/src/features/CasperCustom/MyCasperCardBack.tsx
+++ b/client/src/features/CasperCustom/MyCasperCardBack.tsx
@@ -1,6 +1,6 @@
 import { CASPER_SIZE_OPTION } from "@/constants/CasperCustom/casper";
 import useCasperCustomStateContext from "@/hooks/useCasperCustomStateContext";
-import CasperCardBackUI from "./CasperCardBackUI";
+import { CasperCardBackUI } from "./CasperCardBackUI";
 
 interface MyCasperCardBackProps {
     size?: (typeof CASPER_SIZE_OPTION)[keyof typeof CASPER_SIZE_OPTION];
@@ -8,11 +8,7 @@ interface MyCasperCardBackProps {
     expectations?: string;
 }
 
-export default function MyCasperCardBack({
-    size,
-    casperName,
-    expectations,
-}: MyCasperCardBackProps) {
+export function MyCasperCardBack({ size, casperName, expectations }: MyCasperCardBackProps) {
     const { selectedCasperIdx } = useCasperCustomStateContext();
 
     return (

--- a/client/src/features/CasperCustom/MyCasperCardFront.tsx
+++ b/client/src/features/CasperCustom/MyCasperCardFront.tsx
@@ -2,7 +2,7 @@ import { CASPER_SIZE_OPTION } from "@/constants/CasperCustom/casper";
 import useCasperCustomDispatchContext from "@/hooks/useCasperCustomDispatchContext";
 import useCasperCustomStateContext from "@/hooks/useCasperCustomStateContext";
 import { CASPER_ACTION } from "@/types/casperCustom";
-import CasperCardFrontUI from "./CasperCardFrontUI";
+import { CasperCardFrontUI } from "./CasperCardFrontUI";
 
 interface MyCasperCardFrontProps {
     size?: (typeof CASPER_SIZE_OPTION)[keyof typeof CASPER_SIZE_OPTION];
@@ -11,7 +11,7 @@ interface MyCasperCardFrontProps {
     hasRandomButton?: boolean;
 }
 
-export default function MyCasperCardFront({
+export function MyCasperCardFront({
     size,
     optionDescription,
     casperName,

--- a/client/src/features/CasperCustom/SharedPanel.tsx
+++ b/client/src/features/CasperCustom/SharedPanel.tsx
@@ -1,7 +1,7 @@
 import { Fragment, ReactNode } from "react";
 import Category from "@/components/Category";
 import { CUSTOM_OPTION } from "@/constants/CasperCustom/casper";
-import CasperCustomPanelLayout from "./CasperCustomPanelLayout";
+import { CasperCustomPanelLayout } from "./CasperCustomPanelLayout";
 
 type CustomOptionType = (typeof CUSTOM_OPTION)[keyof typeof CUSTOM_OPTION];
 type OptionListItemType = {
@@ -14,7 +14,7 @@ interface SharedPanelProps {
     basicOptions?: OptionListItemType[];
 }
 
-export default function SharedPanel({ limitedOptions, basicOptions }: SharedPanelProps) {
+export function SharedPanel({ limitedOptions, basicOptions }: SharedPanelProps) {
     const hasLimitedOptions = limitedOptions && limitedOptions.length !== 0;
     const hasBasicOptions = basicOptions && basicOptions.length !== 0;
 

--- a/client/src/features/CasperCustom/index.tsx
+++ b/client/src/features/CasperCustom/index.tsx
@@ -1,0 +1,4 @@
+export { CasperCustomFinish } from "./CasperCustomFinish";
+export { CasperCustomFinishing } from "./CasperCustomFinishing";
+export { CasperCustomProcess } from "./CasperCustomProcess";
+export { CasperCustomForm } from "./CasperCustomForm";

--- a/client/src/features/CasperShowCase/CasperCards.tsx
+++ b/client/src/features/CasperShowCase/CasperCards.tsx
@@ -1,11 +1,11 @@
 import { CASPER_CARD_SIZE, CASPER_SIZE_OPTION } from "@/constants/CasperCustom/casper";
-import TransitionCasperCards, { CasperCardType } from "./TransitionCasperCards";
+import { CasperCardType, TransitionCasperCards } from "./TransitionCasperCards";
 
 interface CasperCardsProps {
     cardList: CasperCardType[];
 }
 
-export default function CasperCards({ cardList }: CasperCardsProps) {
+export function CasperCards({ cardList }: CasperCardsProps) {
     const cardLength = cardList.length;
     const cardLengthHalf = Math.floor(cardLength / 2);
     const topCardList = cardList.slice(0, cardLengthHalf);

--- a/client/src/features/CasperShowCase/TransitionCasperCards.tsx
+++ b/client/src/features/CasperShowCase/TransitionCasperCards.tsx
@@ -4,7 +4,7 @@ import { CASPER_CARD_SIZE, CASPER_SIZE_OPTION } from "@/constants/CasperCustom/c
 import { CARD_TRANSITION } from "@/constants/CasperShowCase/showCase";
 import useLazyLoading from "@/hooks/useLazyLoading";
 import { SelectedCasperIdxType } from "@/types/casperCustom";
-import CasperFlipCard from "../CasperCustom/CasperFlipCard";
+import { CasperFlipCard } from "../CasperCustom/CasperFlipCard";
 
 export interface CasperCardType {
     id: string;

--- a/client/src/features/CasperShowCase/TransitionCasperCards.tsx
+++ b/client/src/features/CasperShowCase/TransitionCasperCards.tsx
@@ -21,7 +21,7 @@ interface TransitionCasperCardsProps {
     isEndCard: (latestX: number) => boolean;
 }
 
-export default function TransitionCasperCards({
+export function TransitionCasperCards({
     cardList,
     initialX,
     diffX,

--- a/client/src/features/CasperShowCase/index.tsx
+++ b/client/src/features/CasperShowCase/index.tsx
@@ -1,0 +1,1 @@
+export { CasperCards } from "./CasperCards";

--- a/client/src/features/Lottery/CustomDesign.tsx
+++ b/client/src/features/Lottery/CustomDesign.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
-import Description from "./Description";
-import Section from "./Section";
+import { Description } from "./Description";
+import { Section } from "./Section";
 
-export default function CustomDesign({ id }: SectionKeyProps) {
+export function CustomDesign({ id }: SectionKeyProps) {
     return (
         <Section id={id}>
             <div className="w-[1200px]">

--- a/client/src/features/Lottery/Description.tsx
+++ b/client/src/features/Lottery/Description.tsx
@@ -19,7 +19,7 @@ const titleContainerVariants = cva(`flex`, {
     },
 });
 
-export default function Description({
+export function Description({
     direction = "horizontal",
     label,
     title,

--- a/client/src/features/Lottery/HeadLamp.tsx
+++ b/client/src/features/Lottery/HeadLamp.tsx
@@ -2,10 +2,10 @@ import { motion } from "framer-motion";
 import Tooltip from "@/components/Tooltip";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
-import Description from "./Description";
-import Section from "./Section";
+import { Description } from "./Description";
+import { Section } from "./Section";
 
-export default function HeadLamp({ id }: SectionKeyProps) {
+export function HeadLamp({ id }: SectionKeyProps) {
     return (
         <Section id={id}>
             <div className="w-[1200px]">

--- a/client/src/features/Lottery/Headline.tsx
+++ b/client/src/features/Lottery/Headline.tsx
@@ -8,7 +8,7 @@ interface HeadlineProps extends SectionKeyProps {
     handleClickShortCutButton: () => void;
 }
 
-export default function Headline({ id, handleClickShortCutButton }: HeadlineProps) {
+export function Headline({ id, handleClickShortCutButton }: HeadlineProps) {
     return (
         <section
             id={id}

--- a/client/src/features/Lottery/Intro.tsx
+++ b/client/src/features/Lottery/Intro.tsx
@@ -2,7 +2,7 @@ import { motion } from "framer-motion";
 import { ASCEND, DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function Intro({ id }: SectionKeyProps) {
+export function Intro({ id }: SectionKeyProps) {
     return (
         <section id={id} className="h-screen relative flex flex-col snap-start">
             <motion.div

--- a/client/src/features/Lottery/NewColor.tsx
+++ b/client/src/features/Lottery/NewColor.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
-import Description from "./Description";
-import Section from "./Section";
+import { Description } from "./Description";
+import { Section } from "./Section";
 
-export default function NewColor({ id }: SectionKeyProps) {
+export function NewColor({ id }: SectionKeyProps) {
     return (
         <Section id={id} className="bg-n-neutral-50">
             <Description

--- a/client/src/features/Lottery/PixelDesign.tsx
+++ b/client/src/features/Lottery/PixelDesign.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
-import Description from "./Description";
-import Section from "./Section";
+import { Description } from "./Description";
+import { Section } from "./Section";
 
-export default function PixelDesign({ id }: SectionKeyProps) {
+export function PixelDesign({ id }: SectionKeyProps) {
     return (
         <Section id={id}>
             <div className="w-[1200px]">

--- a/client/src/features/Lottery/Section.tsx
+++ b/client/src/features/Lottery/Section.tsx
@@ -5,7 +5,7 @@ interface SectionProps extends PropsWithChildren, SectionKeyProps {
     className?: string;
 }
 
-export default function Section({ id, children, className }: SectionProps) {
+export function Section({ id, children, className }: SectionProps) {
     return (
         <section
             id={id}

--- a/client/src/features/Lottery/ShortCut.tsx
+++ b/client/src/features/Lottery/ShortCut.tsx
@@ -7,7 +7,7 @@ interface ShortCutProps extends SectionKeyProps {
     handleClickShortCutButton: () => void;
 }
 
-export default function ShortCut({ id, handleClickShortCutButton }: ShortCutProps) {
+export function ShortCut({ id, handleClickShortCutButton }: ShortCutProps) {
     return (
         <motion.section
             id={id}

--- a/client/src/features/Lottery/SmileBadge.tsx
+++ b/client/src/features/Lottery/SmileBadge.tsx
@@ -2,10 +2,10 @@ import { motion } from "framer-motion";
 import Tooltip from "@/components/Tooltip";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
-import Description from "./Description";
-import Section from "./Section";
+import { Description } from "./Description";
+import { Section } from "./Section";
 
-export default function SmileBadge({ id }: SectionKeyProps) {
+export function SmileBadge({ id }: SectionKeyProps) {
     return (
         <Section id={id} className="bg-n-neutral-50 overflow-hidden relative">
             <img

--- a/client/src/features/Lottery/WheelDesign.tsx
+++ b/client/src/features/Lottery/WheelDesign.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
-import Description from "./Description";
-import Section from "./Section";
+import { Description } from "./Description";
+import { Section } from "./Section";
 
-export default function WheelDesign({ id }: SectionKeyProps) {
+export function WheelDesign({ id }: SectionKeyProps) {
     return (
         <Section id={id}>
             <div className="w-[1200px] flex flex-col items-end">

--- a/client/src/features/Lottery/index.tsx
+++ b/client/src/features/Lottery/index.tsx
@@ -1,0 +1,9 @@
+export { HeadLamp } from "./HeadLamp";
+export { Headline } from "./Headline";
+export { Intro } from "./Intro";
+export { NewColor } from "./NewColor";
+export { PixelDesign } from "./PixelDesign";
+export { ShortCut } from "./ShortCut";
+export { SmileBadge } from "./SmileBadge";
+export { WheelDesign } from "./WheelDesign";
+export { CustomDesign } from "./CustomDesign";

--- a/client/src/features/Main/Headline.tsx
+++ b/client/src/features/Main/Headline.tsx
@@ -4,7 +4,7 @@ import Scroll from "@/components/Scroll";
 import { ASCEND, ASCEND_DESCEND, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function Headline({ id }: SectionKeyProps) {
+export function Headline({ id }: SectionKeyProps) {
     return (
         <section
             id={id}

--- a/client/src/features/Main/LearnMore.tsx
+++ b/client/src/features/Main/LearnMore.tsx
@@ -3,7 +3,7 @@ import CTAButton from "@/components/CTAButton";
 import { ASCEND, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function LearnMore({ id }: SectionKeyProps) {
+export function LearnMore({ id }: SectionKeyProps) {
     return (
         <section
             id={id}

--- a/client/src/features/Main/Lottery.tsx
+++ b/client/src/features/Main/Lottery.tsx
@@ -1,11 +1,11 @@
 import { Link } from "react-router-dom";
 import LotteryEvent from "@/components/LotteryEvent";
 import { LOTTERY_EVENT_DATA } from "@/constants/Main/lotteryEventData.ts";
-import Section from "@/features/Main/Section.tsx";
+import { Section } from "@/features/Main/Section.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 import ArrowIcon from "/public/assets/icons/arrow.svg?react";
 
-export default function Lottery({ id }: SectionKeyProps) {
+export function Lottery({ id }: SectionKeyProps) {
     return (
         <Section
             id={id}

--- a/client/src/features/Main/Rush.tsx
+++ b/client/src/features/Main/Rush.tsx
@@ -1,5 +1,5 @@
 import RushEvent, { RushEventProps } from "@/components/RushEvent";
-import Section from "@/features/Main/Section.tsx";
+import { Section } from "@/features/Main/Section.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
 // TODO: API로 대체될 데이터
@@ -42,7 +42,7 @@ export const rushEventData: RushEventProps[] = [
     },
 ];
 
-export default function Rush({ id }: SectionKeyProps) {
+export function Rush({ id }: SectionKeyProps) {
     return (
         <Section
             id={id}

--- a/client/src/features/Main/Section.tsx
+++ b/client/src/features/Main/Section.tsx
@@ -14,7 +14,7 @@ interface SectionProps extends PropsWithChildren, SectionKeyProps {
     url?: string;
 }
 
-export default function Section({
+export function Section({
     id,
     backgroundColor,
     title,

--- a/client/src/features/Main/index.tsx
+++ b/client/src/features/Main/index.tsx
@@ -1,0 +1,4 @@
+export { Rush } from "./Rush";
+export { Lottery } from "./Lottery";
+export { LearnMore } from "./LearnMore";
+export { Headline } from "./Headline";

--- a/client/src/features/Rush/Background.tsx
+++ b/client/src/features/Rush/Background.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from "react";
 import { motion } from "framer-motion";
 import { ASCEND, SCROLL_MOTION } from "@/constants/animation.ts";
 
-export default function Background({ children }: PropsWithChildren) {
+export function Background({ children }: PropsWithChildren) {
     return (
         <motion.div className="relative z-10" {...SCROLL_MOTION(ASCEND)}>
             <div className="absolute top-0 left-[-38px] w-[880px] h-[390px] rounded-[29px] overflow-hidden bg-n-white/[.16] -rotate-[4deg] z-20">

--- a/client/src/features/Rush/BalanceGame.tsx
+++ b/client/src/features/Rush/BalanceGame.tsx
@@ -2,10 +2,10 @@ import { motion } from "framer-motion";
 import CTAButton from "@/components/CTAButton";
 import Scroll from "@/components/Scroll";
 import { ASCEND, ASCEND_DESCEND, SCROLL_MOTION } from "@/constants/animation.ts";
-import Background from "@/features/Rush/Background.tsx";
+import { Background } from "@/features/Rush/Background.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function BalanceGame({ id }: SectionKeyProps) {
+export function BalanceGame({ id }: SectionKeyProps) {
     return (
         <section
             id={id}

--- a/client/src/features/Rush/CasperCharge.tsx
+++ b/client/src/features/Rush/CasperCharge.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
-import CasperDescription from "@/features/Rush/CasperDescription.tsx";
-import CasperSection from "@/features/Rush/CasperSection.tsx";
+import { CasperDescription } from "@/features/Rush/CasperDescription.tsx";
+import { CasperSection } from "@/features/Rush/CasperSection.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function CasperCharge({ id }: SectionKeyProps) {
+export function CasperCharge({ id }: SectionKeyProps) {
     return (
         <CasperSection id={id}>
             <CasperDescription

--- a/client/src/features/Rush/CasperComfortable.tsx
+++ b/client/src/features/Rush/CasperComfortable.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
-import CasperDescription from "@/features/Rush/CasperDescription.tsx";
-import CasperSection from "@/features/Rush/CasperSection.tsx";
+import { CasperDescription } from "@/features/Rush/CasperDescription.tsx";
+import { CasperSection } from "@/features/Rush/CasperSection.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function CasperComfortable({ id }: SectionKeyProps) {
+export function CasperComfortable({ id }: SectionKeyProps) {
     return (
         <CasperSection id={id}>
             <CasperDescription

--- a/client/src/features/Rush/CasperDescription.tsx
+++ b/client/src/features/Rush/CasperDescription.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 import { motion } from "framer-motion";
 import { ASCEND, SCROLL_MOTION } from "@/constants/animation.ts";
-import CasperSubDescription from "@/features/Rush/CasperSubDescription.tsx";
+import { CasperSubDescription } from "@/features/Rush/CasperSubDescription.tsx";
 
 interface CasperDescriptionProps {
     title: ReactNode;
@@ -9,11 +9,7 @@ interface CasperDescriptionProps {
     description?: string[] | ReactNode;
 }
 
-export default function CasperDescription({
-    title,
-    subTitle,
-    description,
-}: CasperDescriptionProps) {
+export function CasperDescription({ title, subTitle, description }: CasperDescriptionProps) {
     return (
         <div className="flex gap-[42px]">
             <motion.h2 className="h-heading-2-bold text-s-blue" {...SCROLL_MOTION(ASCEND)}>

--- a/client/src/features/Rush/CasperFar.tsx
+++ b/client/src/features/Rush/CasperFar.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
-import CasperDescription from "@/features/Rush/CasperDescription.tsx";
-import CasperSection from "@/features/Rush/CasperSection.tsx";
+import { CasperDescription } from "@/features/Rush/CasperDescription.tsx";
+import { CasperSection } from "@/features/Rush/CasperSection.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function CasperFar({ id }: SectionKeyProps) {
+export function CasperFar({ id }: SectionKeyProps) {
     return (
         <CasperSection id={id}>
             <CasperDescription

--- a/client/src/features/Rush/CasperFast.tsx
+++ b/client/src/features/Rush/CasperFast.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
-import CasperDescription from "@/features/Rush/CasperDescription.tsx";
-import CasperSection from "@/features/Rush/CasperSection.tsx";
+import { CasperDescription } from "@/features/Rush/CasperDescription.tsx";
+import { CasperSection } from "@/features/Rush/CasperSection.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function CasperFast({ id }: SectionKeyProps) {
+export function CasperFast({ id }: SectionKeyProps) {
     return (
         <CasperSection id={id}>
             <CasperDescription

--- a/client/src/features/Rush/CasperSection.tsx
+++ b/client/src/features/Rush/CasperSection.tsx
@@ -4,7 +4,7 @@ import { SectionKeyProps } from "@/types/sections.ts";
 interface CasperSectionProps extends PropsWithChildren, SectionKeyProps {
     className?: string;
 }
-export default function CasperSection({ id, children, className }: CasperSectionProps) {
+export function CasperSection({ id, children, className }: CasperSectionProps) {
     return (
         <section id={id} className="h-screen flex flex-col items-center justify-center snap-start">
             <div className={`w-[1200px] flex flex-col gap-16 ${className}`}>{children}</div>

--- a/client/src/features/Rush/CasperSmartKey.tsx
+++ b/client/src/features/Rush/CasperSmartKey.tsx
@@ -1,9 +1,9 @@
 import { motion } from "framer-motion";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
-import CasperSubDescription from "@/features/Rush/CasperSubDescription.tsx";
+import { CasperSubDescription } from "@/features/Rush/CasperSubDescription.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function CasperSmartKey({ id }: SectionKeyProps) {
+export function CasperSmartKey({ id }: SectionKeyProps) {
     return (
         <section id={id} className="h-[800px] flex gap-10 justify-center items-center snap-start">
             <motion.img

--- a/client/src/features/Rush/CasperSubDescription.tsx
+++ b/client/src/features/Rush/CasperSubDescription.tsx
@@ -7,7 +7,7 @@ interface CasperDescriptionProps {
     description?: string[] | ReactNode;
 }
 
-export default function CasperSubDescription({ subTitle, description }: CasperDescriptionProps) {
+export function CasperSubDescription({ subTitle, description }: CasperDescriptionProps) {
     return (
         <motion.div className="flex flex-col gap-400 text-n-neutral-950" {...SCROLL_MOTION(ASCEND)}>
             <h2 className="h-heading-2-bold">{subTitle}</h2>

--- a/client/src/features/Rush/CasperWide.tsx
+++ b/client/src/features/Rush/CasperWide.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion";
 import { DISSOLVE, SCROLL_MOTION } from "@/constants/animation.ts";
-import CasperDescription from "@/features/Rush/CasperDescription.tsx";
-import CasperSection from "@/features/Rush/CasperSection.tsx";
+import { CasperDescription } from "@/features/Rush/CasperDescription.tsx";
+import { CasperSection } from "@/features/Rush/CasperSection.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function CasperWide({ id }: SectionKeyProps) {
+export function CasperWide({ id }: SectionKeyProps) {
     return (
         <CasperSection id={id} className="items-end">
             <CasperDescription

--- a/client/src/features/Rush/ElectricAdvantage.tsx
+++ b/client/src/features/Rush/ElectricAdvantage.tsx
@@ -1,7 +1,7 @@
 import { ElectricSection } from "@/features/Rush/ElectricSection.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function ElectricAdvantage({ id }: SectionKeyProps) {
+export function ElectricAdvantage({ id }: SectionKeyProps) {
     return (
         <ElectricSection
             id={id}

--- a/client/src/features/Rush/ElectricReason.tsx
+++ b/client/src/features/Rush/ElectricReason.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import Toggle from "@/components/Toggle";
 import { CARD_DATA, TOGGLE_OPTIONS } from "@/constants/Rush/electricCardData.tsx";
-import ElectricReasonCard from "@/features/Rush/ElectricReasonCard.tsx";
+import { ElectricReasonCard } from "@/features/Rush/ElectricReasonCard.tsx";
 import { ElectricSection } from "@/features/Rush/ElectricSection.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function ElectricReason({ id }: SectionKeyProps) {
+export function ElectricReason({ id }: SectionKeyProps) {
     const [selectedIdx, setSelectedIdx] = useState(0);
 
     const handleToggle = (idx: number) => {

--- a/client/src/features/Rush/ElectricReasonCard.tsx
+++ b/client/src/features/Rush/ElectricReasonCard.tsx
@@ -12,7 +12,7 @@ interface ElectricReasonCardProps {
     data: CardData;
 }
 
-export default function ElectricReasonCard({ data }: ElectricReasonCardProps) {
+export function ElectricReasonCard({ data }: ElectricReasonCardProps) {
     return (
         <motion.div
             className="flex flex-col justify-center items-center p-8 h-[600px] w-[730px] mt-8 gap-8 rounded-500 border-2"

--- a/client/src/features/Rush/FAQ.tsx
+++ b/client/src/features/Rush/FAQ.tsx
@@ -2,7 +2,7 @@ import { motion } from "framer-motion";
 import { ASCEND, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function FAQ({ id }: SectionKeyProps) {
+export function FAQ({ id }: SectionKeyProps) {
     return (
         <section
             id={id}

--- a/client/src/features/Rush/Intro.tsx
+++ b/client/src/features/Rush/Intro.tsx
@@ -2,7 +2,7 @@ import { motion } from "framer-motion";
 import { ASCEND, SCROLL_MOTION } from "@/constants/animation.ts";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function Intro({ id }: SectionKeyProps) {
+export function Intro({ id }: SectionKeyProps) {
     return (
         <section
             id={id}

--- a/client/src/features/Rush/ReasonFirst.tsx
+++ b/client/src/features/Rush/ReasonFirst.tsx
@@ -1,7 +1,7 @@
-import ReasonSection from "@/features/Rush/ReasonSection.tsx";
+import { ReasonSection } from "@/features/Rush/ReasonSection.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function ReasonFirst({ id }: SectionKeyProps) {
+export function ReasonFirst({ id }: SectionKeyProps) {
     return (
         <ReasonSection id={id} subtitle="캐스퍼 일렉트릭으로 전기차를 입문해야하는 이유">
             <p>전기차가 처음이라면</p>

--- a/client/src/features/Rush/ReasonSecond.tsx
+++ b/client/src/features/Rush/ReasonSecond.tsx
@@ -1,7 +1,7 @@
-import ReasonSection from "@/features/Rush/ReasonSection.tsx";
+import { ReasonSection } from "@/features/Rush/ReasonSection.tsx";
 import { SectionKeyProps } from "@/types/sections.ts";
 
-export default function ReasonSecond({ id }: SectionKeyProps) {
+export function ReasonSecond({ id }: SectionKeyProps) {
     return (
         <ReasonSection id={id} subtitle="캐스퍼 일렉트릭으로 전기차를 입문해야하는 이유">
             <p className="text-s-blue">라이프스타일 그대로</p>

--- a/client/src/features/Rush/ReasonSection.tsx
+++ b/client/src/features/Rush/ReasonSection.tsx
@@ -8,7 +8,7 @@ interface ReasonSectionProps extends SectionKeyProps {
     children: ReactNode;
 }
 
-export default function ReasonSection({ id, subtitle, children }: ReasonSectionProps) {
+export function ReasonSection({ id, subtitle, children }: ReasonSectionProps) {
     return (
         <section
             id={id}

--- a/client/src/features/Rush/index.tsx
+++ b/client/src/features/Rush/index.tsx
@@ -1,0 +1,13 @@
+export { CasperComfortable } from "./CasperComfortable.tsx";
+export { CasperFar } from "./CasperFar.tsx";
+export { CasperFast } from "./CasperFast.tsx";
+export { CasperSmartKey } from "./CasperSmartKey.tsx";
+export { CasperWide } from "./CasperWide.tsx";
+export { ElectricAdvantage } from "./ElectricAdvantage.tsx";
+export { ElectricReason } from "./ElectricReason.tsx";
+export { FAQ } from "./FAQ.tsx";
+export { Intro } from "./Intro.tsx";
+export { ReasonFirst } from "./ReasonFirst.tsx";
+export { ReasonSecond } from "./ReasonSecond.tsx";
+export { CasperCharge } from "./CasperCharge.tsx";
+export { BalanceGame } from "./BalanceGame.tsx";

--- a/client/src/pages/CasperCustom/index.tsx
+++ b/client/src/pages/CasperCustom/index.tsx
@@ -7,10 +7,12 @@ import {
 } from "@/constants/CasperCustom/customStep";
 import { DISSOLVE } from "@/constants/animation";
 import { CasperCustomProvider } from "@/contexts/casperCustomContext";
-import CasperCustomFinish from "@/features/CasperCustom/CasperCustomFinish";
-import CasperCustomFinishing from "@/features/CasperCustom/CasperCustomFinishing";
-import CasperCustomForm from "@/features/CasperCustom/CasperCustomForm";
-import CasperCustomProcess from "@/features/CasperCustom/CasperCustomProcess";
+import {
+    CasperCustomFinish,
+    CasperCustomFinishing,
+    CasperCustomForm,
+    CasperCustomProcess,
+} from "@/features/CasperCustom";
 
 const INITIAL_STEP = 0;
 

--- a/client/src/pages/CasperShowCase/index.tsx
+++ b/client/src/pages/CasperShowCase/index.tsx
@@ -2,7 +2,7 @@ import { motion } from "framer-motion";
 import CTAButton from "@/components/CTAButton";
 import { CUSTOM_OPTION } from "@/constants/CasperCustom/casper";
 import { ASCEND, DISSOLVE } from "@/constants/animation";
-import CasperCards from "@/features/CasperShowCase/CasperCards";
+import { CasperCards } from "@/features/CasperShowCase";
 
 // TODO: 나중에 후처리 부분도 API 폴더에 빼기
 function getCardListData() {

--- a/client/src/pages/Lottery/index.tsx
+++ b/client/src/pages/Lottery/index.tsx
@@ -2,15 +2,17 @@ import { useState } from "react";
 import Footer from "@/components/Footer";
 import Notice from "@/components/Notice";
 import { LOTTERY_SECTIONS } from "@/constants/PageSections/sections.ts";
-import CustomDesign from "@/features/Lottery/CustomDesign";
-import HeadLamp from "@/features/Lottery/HeadLamp";
-import Headline from "@/features/Lottery/Headline";
-import Intro from "@/features/Lottery/Intro";
-import NewColor from "@/features/Lottery/NewColor";
-import PixelDesign from "@/features/Lottery/PixelDesign";
-import ShortCut from "@/features/Lottery/ShortCut";
-import SmileBadge from "@/features/Lottery/SmileBadge";
-import WheelDesign from "@/features/Lottery/WheelDesign";
+import {
+    CustomDesign,
+    HeadLamp,
+    Headline,
+    Intro,
+    NewColor,
+    PixelDesign,
+    ShortCut,
+    SmileBadge,
+    WheelDesign,
+} from "@/features/Lottery";
 import useHeaderStyleObserver from "@/hooks/useHeaderStyleObserver.ts";
 import usePhoneNumberDispatchContext from "@/hooks/usePhoneNumberDispatchContext";
 import usePhoneNumberStateContext from "@/hooks/usePhoneNumberStateContext";

--- a/client/src/pages/Lottery/index.tsx
+++ b/client/src/pages/Lottery/index.tsx
@@ -60,7 +60,7 @@ export default function Lottery() {
     };
 
     return (
-        <div ref={containerRef} className="h-screen overflow-auto snap-y snap-mandatory">
+        <div ref={containerRef} className="h-screen overflow-x-hidden snap-y snap-mandatory">
             <Headline
                 id={LOTTERY_SECTIONS.HEADLINE}
                 handleClickShortCutButton={handleClickShortCut}

--- a/client/src/pages/Main/index.tsx
+++ b/client/src/pages/Main/index.tsx
@@ -1,10 +1,7 @@
 import Footer from "@/components/Footer";
 import Notice from "@/components/Notice";
 import { MAIN_SECTIONS } from "@/constants/PageSections/sections.ts";
-import Headline from "@/features/Main/Headline.tsx";
-import LearnMore from "@/features/Main/LearnMore.tsx";
-import Lottery from "@/features/Main/Lottery.tsx";
-import Rush from "@/features/Main/Rush.tsx";
+import { Headline, LearnMore, Lottery, Rush } from "@/features/Main";
 import useHeaderStyleObserver from "@/hooks/useHeaderStyleObserver.ts";
 import useScrollTop from "@/hooks/useScrollTop.tsx";
 

--- a/client/src/pages/Rush/index.tsx
+++ b/client/src/pages/Rush/index.tsx
@@ -1,19 +1,21 @@
 import Footer from "@/components/Footer";
 import Notice from "@/components/Notice";
 import { RUSH_SECTIONS } from "@/constants/PageSections/sections.ts";
-import BalanceGame from "@/features/Rush/BalanceGame.tsx";
-import CasperCharge from "@/features/Rush/CasperCharge.tsx";
-import CasperComfortable from "@/features/Rush/CasperComfortable.tsx";
-import CasperFar from "@/features/Rush/CasperFar.tsx";
-import CasperFast from "@/features/Rush/CasperFast.tsx";
-import CasperSmartKey from "@/features/Rush/CasperSmartKey.tsx";
-import CasperWide from "@/features/Rush/CasperWide.tsx";
-import ElectricAdvantage from "@/features/Rush/ElectricAdvantage.tsx";
-import ElectricReason from "@/features/Rush/ElectricReason.tsx";
-import FAQ from "@/features/Rush/FAQ.tsx";
-import Intro from "@/features/Rush/Intro.tsx";
-import ReasonFirst from "@/features/Rush/ReasonFirst.tsx";
-import ReasonSecond from "@/features/Rush/ReasonSecond.tsx";
+import {
+    BalanceGame,
+    CasperCharge,
+    CasperComfortable,
+    CasperFar,
+    CasperFast,
+    CasperSmartKey,
+    CasperWide,
+    ElectricAdvantage,
+    ElectricReason,
+    FAQ,
+    Intro,
+    ReasonFirst,
+    ReasonSecond,
+} from "@/features/Rush";
 import useHeaderStyleObserver from "@/hooks/useHeaderStyleObserver.ts";
 import useScrollTop from "@/hooks/useScrollTop.tsx";
 


### PR DESCRIPTION
## 🖥️ Preview

없음

close #106

## ✏️ 한 일

- [x] barrel import로 import 구문 정리

## ❗️ 발생한 이슈 (해결 방안)

features 폴더에서 내보내는 컴포넌트가 많아서 import 구문이 길어지고 복잡해지는 경향이 있었습니다. features 컴포넌트를 Import 하는 곳은 보통 page 하나라서 한 번에 묶어서 import 하는게 더 깔끔하다고 생각이 들었습니다. 그래서 index 파일 기반으로 barrel import를 사용해서 하나의 features 폴더에 포함된 파일들은 한 번에 import 될 수 있도록 했습니다.

## ❓ 논의가 필요한 사항
