### PR TITLE
[Feat] Popup Submit 작동 추가

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.sw?
 *.iml
 *storybook.log
+
+.env

--- a/client/src/components/CTAButton/index.tsx
+++ b/client/src/components/CTAButton/index.tsx
@@ -32,6 +32,7 @@ export interface CTAButtonProps extends VariantProps<typeof buttonVariants> {
     url?: string;
     hasArrowIcon?: boolean;
     hasShareIcon?: boolean;
+    type?: "button" | "submit";
 }
 
 export default function CTAButton({
@@ -42,6 +43,7 @@ export default function CTAButton({
     url,
     hasArrowIcon = false,
     hasShareIcon = false,
+    type,
 }: CTAButtonProps) {
     const strokeColor = disabled ? "#637381" : color === "blue" ? "#FFFFFF" : "#04AAD2";
     const status = disabled
@@ -78,7 +80,7 @@ export default function CTAButton({
         );
     }
     return (
-        <button onClick={onClick} disabled={disabled} className={baseClass}>
+        <button onClick={onClick} disabled={disabled} className={baseClass} type={type}>
             {content}
         </button>
     );

--- a/client/src/components/PopUp/index.tsx
+++ b/client/src/components/PopUp/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { PHONE_NUMBER_FORMAT, formatPhoneNumber } from "@/utils/formatPhoneNumber";
 import CTAButton from "../CTAButton";
@@ -41,7 +41,8 @@ export default function PopUp({
         handlePhoneNumberChange(formattedPhoneNumber);
     };
 
-    const handleConfirm = () => {
+    const handleConfirm = (e: FormEvent) => {
+        e.preventDefault();
         handlePhoneNumberConfirm(phoneNumber);
         navigate(confirmUrl);
     };
@@ -52,8 +53,11 @@ export default function PopUp({
                 className="absolute left-0 top-0 w-[100%] h-[100%] bg-n-black/[.4]"
                 onClick={handleClose}
             />
-            <div className="px-[80px] py-[81px] bg-n-white rounded-800 absolute left-[50%] top-[50%] translate-y-[-50%] translate-x-[-50%]">
-                <button className="absolute right-700 top-700" onClick={handleClose}>
+            <form
+                className="px-[80px] py-[81px] bg-n-white rounded-800 absolute left-[50%] top-[50%] translate-y-[-50%] translate-x-[-50%]"
+                onSubmit={handleConfirm}
+            >
+                <button className="absolute right-700 top-700" type="button" onClick={handleClose}>
                     <img alt="팝업 닫기 버튼" src="/assets/icons/close.svg" />
                 </button>
 
@@ -105,10 +109,10 @@ export default function PopUp({
                         disabled={canConfirm ? false : true}
                         color="blue"
                         label="다음"
-                        onClick={handleConfirm}
+                        type="submit"
                     />
                 </div>
-            </div>
+            </form>
         </div>
     );
 }


### PR DESCRIPTION
## 🖥️ Preview


https://github.com/user-attachments/assets/2d776859-8abb-4d29-9e69-d9614e8e61a7



close #110

## ✏️ 한 일

- [x] Popup에서 전화번호 입력 input에 form 기능(엔터 submit) 추가

## ❗️ 발생한 이슈 (해결 방안)

처음에는 submit이 제대로 동작하지 않았다.

<img width="448" alt="스크린샷 2024-08-07 오후 5 20 19" src="https://github.com/user-attachments/assets/8fca0df2-602d-4e30-ac45-ee5dfa314b7f">

form 액션이 실행되지 않았는데, 찾아보니 form 안에 button이 두 개 있는 경우 submit 행위를 하는 버튼에만 type을 명시해줄 것이 아니라 다른 버튼에도 type="button"을 명시해줘야 제대로 동작한다.

## ❓ 논의가 필요한 사항
