### PR TITLE
[Fix] 메인 페이지 오류 수정

### DIFF
--- a/client/src/constants/cookie.ts
+++ b/client/src/constants/cookie.ts
@@ -1,4 +1,4 @@
 export const COOKIE_KEY = {
     ACCESS_TOKEN: "token",
-    INVITE_USER: "referrerId",
+    INVITE_USER: "referralId",
 } as const;

--- a/client/src/features/CasperCustom/CasperCustomForm.tsx
+++ b/client/src/features/CasperCustom/CasperCustomForm.tsx
@@ -28,9 +28,9 @@ export function CasperCustomForm({ navigateNextStep }: CasperCustomFormProps) {
         fetchData: postCasper,
     } = useFetch<
         PostCasperResponse,
-        { token: string; referrerId: string; casper: CasperInformationType }
-    >(({ token, referrerId, casper }) =>
-        LotteryAPI.postCasper(token, { ...casper, [COOKIE_KEY.INVITE_USER]: referrerId })
+        { token: string; referralId: string; casper: CasperInformationType }
+    >(({ token, referralId, casper }) =>
+        LotteryAPI.postCasper(token, { ...casper, [COOKIE_KEY.INVITE_USER]: referralId })
     );
 
     const { casperName, expectations, selectedCasperIdx } = useCasperCustomStateContext();
@@ -85,7 +85,7 @@ export function CasperCustomForm({ navigateNextStep }: CasperCustomFormProps) {
 
         await postCasper({
             token: cookies[COOKIE_KEY.ACCESS_TOKEN],
-            referrerId: cookies[COOKIE_KEY.INVITE_USER],
+            referralId: cookies[COOKIE_KEY.INVITE_USER],
             casper,
         });
     };

--- a/client/src/hooks/useFetch.ts
+++ b/client/src/hooks/useFetch.ts
@@ -9,6 +9,9 @@ export default function useFetch<T, P = void>(fetch: (params: P) => Promise<T>) 
     const { showBoundary } = useErrorBoundary();
 
     const fetchData = async (params?: P) => {
+        setIsError(false);
+        setIsSuccess(false);
+
         try {
             const data = await fetch(params as P);
             setData(data);

--- a/client/src/pages/ErrorElement/index.tsx
+++ b/client/src/pages/ErrorElement/index.tsx
@@ -5,6 +5,10 @@ interface ErrorElementProps {
 }
 
 export default function ErrorElement({ fallbackUrl = "/" }: ErrorElementProps) {
+    const handleClickButton = () => {
+        window.location.href = fallbackUrl;
+    };
+
     return (
         <div className="fixed z-10 h-screen w-full bg-n-neutral-950 flex flex-col justify-center items-center">
             <img alt="오류 아이콘" src="/assets/icons/casper-error.svg" />
@@ -13,7 +17,7 @@ export default function ErrorElement({ fallbackUrl = "/" }: ErrorElementProps) {
                 문제가 발생했습니다. 잠시 후 다시 시도해 보세요.
             </h3>
             <div className="mt-12" />
-            <CTAButton label="돌아가기" url={fallbackUrl} hasArrowIcon />
+            <CTAButton label="돌아가기" hasArrowIcon onClick={handleClickButton} />
         </div>
     );
 }


### PR DESCRIPTION
## 🖥️ Preview

close #140

## ✏️ 한 일

- [x] 오류 발생 시 나오는 ErrorElement에서 navigate가 동작 안 하는 오류 수정
- [x] 추천인 property명 수정
- [x] useFetch 시 isError, isSuccess 초기화 로직 추가

## ❗️ 발생한 이슈 (해결 방안)

오류 발생 시 나오는 ErrorElement에서 navigate가 동작 안 하는 문제가 있었습니다. 오류가 발생하는 경우 렌더링이 회복되지 못해서 navigate가 되지 않는 것으로 파악해, 돌아가기를 클릭하는 경우 아예 페이지 새로고침을 하도록 구현했습니다.

## ❓ 논의가 필요한 사항

