### PR TITLE
[Feat] 어드민 API 예외처리

### DIFF
--- a/admin/src/apis/authAPI.ts
+++ b/admin/src/apis/authAPI.ts
@@ -10,16 +10,12 @@ const headers = {
 export const AuthAPI = {
     async postAuth(body: PostAuthParams): Promise<PostAuthResponse> {
         try {
-            return new Promise((resolve) =>
-                resolve({
-                    accessToken: "access token",
-                })
-            );
             const response = await fetchWithTimeout(`${baseURL}`, {
                 method: "POST",
                 headers: headers,
                 body: JSON.stringify(body),
             });
+
             return response.json();
         } catch (error) {
             console.error("Error:", error);

--- a/admin/src/hooks/useFetch.ts
+++ b/admin/src/hooks/useFetch.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useErrorBoundary } from "react-error-boundary";
 
-export default function useFetch<T, P = void>(fetch: (params: P) => Promise<T>) {
+export default function useFetch<T, P = void>(fetch: (params: P) => Promise<T>, showError = true) {
     const { showBoundary } = useErrorBoundary();
 
     const [data, setData] = useState<T | null>(null);
@@ -18,8 +18,10 @@ export default function useFetch<T, P = void>(fetch: (params: P) => Promise<T>) 
             setIsSuccess(!!data);
         } catch (error) {
             setIsError(true);
-            showBoundary(error);
             console.error(error);
+            if (showError) {
+                showBoundary(error);
+            }
         }
     };
 

--- a/admin/src/pages/Login/index.tsx
+++ b/admin/src/pages/Login/index.tsx
@@ -20,19 +20,27 @@ export default function Login() {
     const {
         data: token,
         isSuccess: isSuccessPostAuth,
+        isError: isErrorPostAuth,
         fetchData: postAuth,
-    } = useFetch<PostAuthResponse>(() => AuthAPI.postAuth({ adminId: id, password }));
+    } = useFetch<PostAuthResponse>(() => AuthAPI.postAuth({ adminId: id, password }), false);
 
     const isValidButton = id.length !== 0 && password.length !== 0;
 
     useEffect(() => {
         if (isSuccessPostAuth && token) {
-            setCookie(COOKIE_KEY.ACCESS_TOKEN, token.accessToken);
+            setCookie(COOKIE_KEY.ACCESS_TOKEN, token.accessToken, { path: "/" });
 
             setErrorMessage("");
             navigate("/lottery");
         }
     }, [isSuccessPostAuth, token]);
+    useEffect(() => {
+        if (isErrorPostAuth) {
+            setErrorMessage(
+                "아이디 또는 비밀번호가 잘못 되었습니다. 아이디와 비밀번호를 정확히 입력해 주세요."
+            );
+        }
+    }, [isErrorPostAuth]);
 
     const handleChangeId = (e: ChangeEvent<HTMLInputElement>) => {
         setId(e.target.value);

--- a/admin/src/utils/fetchWithTimeout.ts
+++ b/admin/src/utils/fetchWithTimeout.ts
@@ -3,12 +3,12 @@ export async function fetchWithTimeout(url: string, options: RequestInit = {}, t
     const id = setTimeout(() => controller.abort(), timeout);
     options.signal = controller.signal;
 
-    try {
-        const response = await fetch(url, options);
-        clearTimeout(id);
-        return response;
-    } catch (error) {
-        clearTimeout(id);
-        throw error;
+    const response = await fetch(url, options);
+    clearTimeout(id);
+
+    if (!response.ok) {
+        throw new Error(response.statusText);
     }
+
+    return response;
 }

--- a/client/src/utils/fetchWithTimeout.ts
+++ b/client/src/utils/fetchWithTimeout.ts
@@ -3,12 +3,12 @@ export async function fetchWithTimeout(url: string, options: RequestInit = {}, t
     const id = setTimeout(() => controller.abort(), timeout);
     options.signal = controller.signal;
 
-    try {
-        const response = await fetch(url, options);
-        clearTimeout(id);
-        return response;
-    } catch (error) {
-        clearTimeout(id);
-        throw error;
+    const response = await fetch(url, options);
+    clearTimeout(id);
+
+    if (!response.ok) {
+        throw new Error(response.statusText);
     }
+
+    return response;
 }


### PR DESCRIPTION
## 🖥️ Preview

<img width="698" alt="스크린샷 2024-08-13 오후 2 26 42" src="https://github.com/user-attachments/assets/bd694af5-e441-411c-bddb-701c111c6a83">


close #145

## ✏️ 한 일

- [x] 로그인 토큰이 만료된 경우
- [x] 추첨 안 했는데 추첨 이벤트 당첨자 목록에 들어간 경우


## ❗️ 발생한 이슈 (해결 방안)

기존에 로그인이 실패해도 token이 undefined로 들어가고 메인 페이지로 접속이 가능한 문제가 있었습니다. 원인은 fetch에 있었는데, fetch는 오류 응답을 자동으로 예외로 처리하지 않습니다. fetch API는 HTTP 오류 상태 코드(예: 400, 404, 500)를 네트워크 오류로 취급하지 않고, 성공적인 응답으로 간주해서 error를 throw하지 않습니다.

따라서 일반적으로 발생하는 오류를 try/catch하는 코드 뿐만 아니라 status code를 확인하는 코드가 필요했습니다.

status를 확인하기 위해서 respones.ok(200-299 사이의 status를 정상적인 응답으로 간주)를 사용했습니다.

```tsx
export async function fetchWithTimeout(url: string, options: RequestInit = {}, timeout = 5000) {
    const controller = new AbortController();
    const id = setTimeout(() => controller.abort(), timeout);
    options.signal = controller.signal;

    const response = await fetch(url, options);
    clearTimeout(id);

    if (!response.ok) {
        throw new Error(response.statusText);
    }

    return response;
}
```

위와 같이 response.ok가 아닌 경우 error를 throw하게 해서 try/catch 문에 걸리도록 했습니다.

## ❓ 논의가 필요한 사항
