### PR TITLE
[Feat] 캐스퍼 쇼케이스에서 공유 링크 구현

### DIFF
--- a/client/src/features/CasperCustom/Battery.tsx
+++ b/client/src/features/CasperCustom/Battery.tsx
@@ -12,7 +12,6 @@ export function Battery({ applyCount }: BatteryProps) {
     const [batteryApplyArray, setBatteryApplyArray] = useState<boolean[]>(batteryArray);
 
     useEffect(() => {
-        // TODO: 응모 횟수 받아와야함
         const newBatteryApplyArray = batteryApplyArray.map((_, index) => index < applyCount);
         setBatteryApplyArray(newBatteryApplyArray);
     }, [applyCount]);

--- a/client/src/features/CasperCustom/CasperCustomFinish.tsx
+++ b/client/src/features/CasperCustom/CasperCustomFinish.tsx
@@ -32,7 +32,6 @@ export function CasperCustomFinish({
     unblockNavigation,
 }: CasperCustomFinishProps) {
     const [cookies] = useCookies([COOKIE_KEY.ACCESS_TOKEN]);
-    const { showToast, ToastComponent } = useToast("링크가 복사되었어요!");
 
     const { data: applyCountData, fetchData: getApplyCount } = useFetch<GetApplyCountResponse>(() =>
         LotteryAPI.getApplyCount(cookies[COOKIE_KEY.ACCESS_TOKEN])
@@ -41,9 +40,17 @@ export function CasperCustomFinish({
     const {
         data: shareLink,
         isSuccess: isSuccessGetShareLink,
+        isError: isErrorGetShareLink,
         fetchData: getShareLink,
-    } = useFetch<GetShareLinkResponse>(() =>
-        LinkAPI.getShareLink(cookies[COOKIE_KEY.ACCESS_TOKEN])
+    } = useFetch<GetShareLinkResponse>(
+        () => LinkAPI.getShareLink(cookies[COOKIE_KEY.ACCESS_TOKEN]),
+        false
+    );
+
+    const { showToast, ToastComponent } = useToast(
+        isErrorGetShareLink
+            ? "공유 링크 생성에 실패했습니다! 캐스퍼 봇 생성 후 다시 시도해주세요."
+            : "링크가 복사되었어요!"
     );
 
     const dispatch = useCasperCustomDispatchContext();
@@ -54,6 +61,10 @@ export function CasperCustomFinish({
     useEffect(() => {
         if (shareLink && isSuccessGetShareLink) {
             writeClipboard(shareLink.shortenUrl, showToast);
+            return;
+        }
+        if (isErrorGetShareLink) {
+            showToast();
         }
     }, [shareLink, isSuccessGetShareLink]);
     useEffect(() => {

--- a/client/src/hooks/useFetch.ts
+++ b/client/src/hooks/useFetch.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useErrorBoundary } from "react-error-boundary";
 
-export default function useFetch<T, P = void>(fetch: (params: P) => Promise<T>) {
+export default function useFetch<T, P = void>(fetch: (params: P) => Promise<T>, showError = true) {
     const [data, setData] = useState<T | null>(null);
     const [isSuccess, setIsSuccess] = useState<boolean>(false);
     const [isError, setIsError] = useState<boolean>(false);
@@ -17,9 +17,11 @@ export default function useFetch<T, P = void>(fetch: (params: P) => Promise<T>) 
             setData(data);
             setIsSuccess(!!data);
         } catch (error) {
-            showBoundary(error);
             setIsError(true);
             console.error(error);
+            if (showError) {
+                showBoundary(error);
+            }
         }
     };
 

--- a/client/src/pages/CasperShowCase/index.tsx
+++ b/client/src/pages/CasperShowCase/index.tsx
@@ -39,14 +39,21 @@ export default function CasperShowCase() {
     });
 
     const [cookies] = useCookies([COOKIE_KEY.ACCESS_TOKEN]);
-    const { showToast, ToastComponent } = useToast("링크가 복사되었어요!");
 
     const {
         data: shareLink,
         isSuccess: isSuccessGetShareLink,
+        isError: isErrorGetShareLink,
         fetchData: getShareLink,
-    } = useFetch<GetShareLinkResponse>(() =>
-        LinkAPI.getShareLink(cookies[COOKIE_KEY.ACCESS_TOKEN])
+    } = useFetch<GetShareLinkResponse>(
+        () => LinkAPI.getShareLink(cookies[COOKIE_KEY.ACCESS_TOKEN]),
+        false
+    );
+
+    const { showToast, ToastComponent } = useToast(
+        isErrorGetShareLink
+            ? "공유 링크 생성에 실패했습니다! 캐스퍼 봇 생성 후 다시 시도해주세요."
+            : "링크가 복사되었어요!"
     );
 
     const casperList = useLoaderData() as GetCasperListResponse;
@@ -55,8 +62,12 @@ export default function CasperShowCase() {
     useEffect(() => {
         if (shareLink && isSuccessGetShareLink) {
             writeClipboard(shareLink.shortenUrl, showToast);
+            return;
         }
-    }, [shareLink, isSuccessGetShareLink]);
+        if (isErrorGetShareLink) {
+            showToast();
+        }
+    }, [shareLink, isSuccessGetShareLink, isErrorGetShareLink]);
 
     const handleClickShareButton = () => {
         getShareLink();

--- a/client/src/pages/CasperShowCase/index.tsx
+++ b/client/src/pages/CasperShowCase/index.tsx
@@ -1,12 +1,20 @@
+import { useEffect } from "react";
 import { motion } from "framer-motion";
+import { useCookies } from "react-cookie";
 import { useLoaderData } from "react-router-dom";
+import { LinkAPI } from "@/apis/linkAPI";
 import CTAButton from "@/components/CTAButton";
 import { CUSTOM_OPTION } from "@/constants/CasperCustom/casper";
 import { CASPER_SHOWCASE_SECTIONS } from "@/constants/PageSections/sections";
 import { ASCEND, DISSOLVE, SCROLL_MOTION } from "@/constants/animation";
+import { COOKIE_KEY } from "@/constants/cookie";
 import { CasperCards } from "@/features/CasperShowCase";
+import useFetch from "@/hooks/useFetch";
 import useHeaderStyleObserver from "@/hooks/useHeaderStyleObserver";
+import useToast from "@/hooks/useToast";
+import { GetShareLinkResponse } from "@/types/linkApi";
 import { GetCasperListResponse } from "@/types/lotteryApi";
+import { writeClipboard } from "@/utils/writeClipboard";
 
 function getCardListData(cardList: GetCasperListResponse) {
     return cardList.map((card) => {
@@ -30,11 +38,28 @@ export default function CasperShowCase() {
         darkSections: [CASPER_SHOWCASE_SECTIONS.SHOWCASE],
     });
 
+    const [cookies] = useCookies([COOKIE_KEY.ACCESS_TOKEN]);
+    const { showToast, ToastComponent } = useToast("링크가 복사되었어요!");
+
+    const {
+        data: shareLink,
+        isSuccess: isSuccessGetShareLink,
+        fetchData: getShareLink,
+    } = useFetch<GetShareLinkResponse>(() =>
+        LinkAPI.getShareLink(cookies[COOKIE_KEY.ACCESS_TOKEN])
+    );
+
     const casperList = useLoaderData() as GetCasperListResponse;
     const cardListData = getCardListData(casperList);
 
-    const handleClickShare = () => {
-        // TODO: 이벤트 링크 공유 로직
+    useEffect(() => {
+        if (shareLink && isSuccessGetShareLink) {
+            writeClipboard(shareLink.shortenUrl, showToast);
+        }
+    }, [shareLink, isSuccessGetShareLink]);
+
+    const handleClickShareButton = () => {
+        getShareLink();
     };
 
     return (
@@ -55,10 +80,12 @@ export default function CasperShowCase() {
                 </motion.div>
 
                 <motion.div className="flex gap-500" {...SCROLL_MOTION(ASCEND)}>
-                    <CTAButton label="이벤트 링크 공유" onClick={handleClickShare} />
+                    <CTAButton label="이벤트 링크 공유" onClick={handleClickShareButton} />
                     <CTAButton label="메인으로 돌아가기" url="/" color="white" />
                 </motion.div>
             </section>
+
+            {ToastComponent}
         </div>
     );
 }

--- a/client/src/utils/writeClipboard.ts
+++ b/client/src/utils/writeClipboard.ts
@@ -1,0 +1,13 @@
+export async function writeClipboard(
+    text: string,
+    successCallback?: () => void,
+    errorCallback?: () => void
+) {
+    try {
+        await navigator.clipboard.writeText(text);
+        successCallback && successCallback();
+    } catch (err) {
+        console.error("Failed to copy: ", err);
+        errorCallback && errorCallback();
+    }
+}


### PR DESCRIPTION
## 🖥️ Preview


https://github.com/user-attachments/assets/92bb30dd-3180-4445-a1e0-09900e07f60a



close #154


## ✏️ 한 일

- [x] 쇼케이스 페이지에서 공유 링크 로직 구현

## ❗️ 발생한 이슈 (해결 방안)

제가 캐스퍼 봇 생성 완료 후 나타나는 화면에서의 공유 버튼에만 API 연동을 해줬길래 쇼케이스 페이지의 공유 버튼에도 link share API 연동을 추가했습니당,,😅

## ❓ 논의가 필요한 사항

