### PR TITLE
[Fix] 전체적인 UI 오류 수정

### DIFF
--- a/client/src/features/Main/Lottery.tsx
+++ b/client/src/features/Main/Lottery.tsx
@@ -75,13 +75,15 @@ function Lottery({ id }: SectionKeyProps) {
                     </div>
                 </div>
             </div>
-            <Link
-                to="/lottery/show-case"
-                className="flex w-[1200px] justify-end gap-1 h-body-1-regular text-n-neutral-500 hover:underline"
-            >
-                <p>다른 사람들의 스마일 로봇 뱃지 보러가기</p>
-                <ArrowRightIcon stroke="#637381" />
-            </Link>
+            <div className="flex justify-end">
+                <Link
+                    to="/lottery/show-case"
+                    className="flex gap-1 hover:underline h-body-1-regular text-n-neutral-500"
+                >
+                    <p>다른 사람들의 스마일 로봇 뱃지 보러가기</p>
+                    <ArrowRightIcon stroke="#637381" />
+                </Link>
+            </div>
         </Section>
     );
 }

--- a/client/src/features/RushGame/RushGameComponents/RushBar.tsx
+++ b/client/src/features/RushGame/RushGameComponents/RushBar.tsx
@@ -31,7 +31,7 @@ interface BarProps extends BarVariantsProps {
 export default function RushBar({ ratio, color, status, textAlign }: BarProps) {
     return (
         <span className={barVariants({ color, status, textAlign })} style={{ width: `${ratio}%` }}>
-            <p className="px-3">{ratio}%</p>
+            <p className="px-3 z-40">{ratio}%</p>
         </span>
     );
 }

--- a/client/src/features/RushGame/RushGameComponents/RushCardCurrentRatio.tsx
+++ b/client/src/features/RushGame/RushGameComponents/RushCardCurrentRatio.tsx
@@ -1,3 +1,4 @@
+import { cva } from "class-variance-authority";
 import Tooltip from "@/components/Tooltip";
 import { CARD_OPTION } from "@/constants/Rush/rushCard.ts";
 import RushCurrentOptionDisplay from "@/features/RushGame/RushGameComponents/RushCurrentOptionDisplay.tsx";
@@ -6,6 +7,18 @@ import { useRushGameContext } from "@/hooks/useRushGameContext.ts";
 import useToggleContents from "@/hooks/useToggleContents.ts";
 import { CardOption } from "@/types/rushGame.ts";
 import Reload from "/public/assets/icons/reload.svg?react";
+
+const tooltipVariants = cva(`absolute transition-opacity duration-300 ease-in-out`, {
+    variants: {
+        visible: {
+            true: "opacity-1 visibility-visible",
+            false: "opacity-0 visibility-hidden",
+        },
+    },
+    defaultVariants: {
+        visible: true,
+    },
+});
 
 const TOOLTIP_CONTENT = () => (
     <>
@@ -77,17 +90,12 @@ export default function RushCardCurrentRatio() {
                 />
             </div>
             <div className="absolute right-6 bottom-6">
-                {toggleContents ? (
-                    <Tooltip content={TOOLTIP_CONTENT()} tooltipPosition="left">
-                        <button onClick={fetchRushBalance}>
-                            <Reload />
-                        </button>
-                    </Tooltip>
-                ) : (
-                    <button onClick={fetchRushBalance}>
-                        <Reload />
-                    </button>
-                )}
+                <div className={tooltipVariants({ visible: toggleContents })}>
+                    <Tooltip content={TOOLTIP_CONTENT()} tooltipPosition="left" />
+                </div>
+                <button onClick={fetchRushBalance}>
+                    <Reload />
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
## 🖥️ Preview
### 1. "다른 사람들의 스마일 로봇 뱃지 보러가기" width 오류 수정
https://github.com/user-attachments/assets/876fa02d-ce05-43bd-89c0-be1057ddae65

### 2. 새로고침 툴팁 부드럽게 사라지는 애니메이션
https://github.com/user-attachments/assets/28418cb5-ab2f-4f33-a9bf-e21fc1d9e0a0

### 3. 비율 텍스트 z-index 설정 (프로그래스 막대기에 가려져 안보이는 오류 수정)
<img width="907" alt="스크린샷 2024-08-18 오후 7 39 49" src="https://github.com/user-attachments/assets/226340e0-0cfb-45f5-b9a7-253039fd665a">

close #166 

## ✏️ 한 일
- [x] 1. Main 페이지의 Lottery → 다른 사람들의 스마일 로봇~~ 여기 부분 같은 라인에서 hover 잡히는 오류
- [x] 2. 새로고침 툴팁 메시지 부드럽게 사라지는 인터렉션 추가 
- [x] 3. 프로그래스바 비율 보여주는 텍스트가 프로그래스바에 가려지는 오류(내부 텍스트 z-index 설정)

## ❗️ 발생한 이슈 (해결 방안)

## ❓ 논의가 필요한 사항
