### PR TITLE
[Feat] RushCard 색상 랜덤 기능 구현

### DIFF
--- a/client/src/constants/Rush/rushCard.ts
+++ b/client/src/constants/Rush/rushCard.ts
@@ -1,5 +1,3 @@
-import { CardColor } from "@/types/rushGame.ts";
-
 export const CARD_PHASE = {
     NOT_STARTED: "NOT_STARTED",
     IN_PROGRESS: "IN_PROGRESS",
@@ -23,49 +21,3 @@ export const WIN_STATUS = {
     LOSE: "Lose",
     TIE: "Tie",
 } as const;
-
-// TODO: 카드 색상 랜덤 기능 구현 후 불필요한 상수 데이터 삭제 (CARD_DAYS, CARD_COLORS)
-export const CARD_DAYS = {
-    DAY1: 1,
-    DAY2: 2,
-    DAY3: 3,
-    DAY4: 4,
-    DAY5: 5,
-    DAY6: 6,
-} as const;
-
-type CardColorOptions = {
-    [CARD_OPTION.LEFT_OPTIONS]: CardColor;
-    [CARD_OPTION.RIGHT_OPTIONS]: CardColor;
-};
-
-type CardColorType = {
-    [key in (typeof CARD_DAYS)[keyof typeof CARD_DAYS]]: CardColorOptions;
-};
-
-export const CARD_COLORS: CardColorType = {
-    [CARD_DAYS.DAY1]: {
-        [CARD_OPTION.LEFT_OPTIONS]: CARD_COLOR.GREEN,
-        [CARD_OPTION.RIGHT_OPTIONS]: CARD_COLOR.BLUE,
-    },
-    [CARD_DAYS.DAY2]: {
-        [CARD_OPTION.LEFT_OPTIONS]: CARD_COLOR.YELLOW,
-        [CARD_OPTION.RIGHT_OPTIONS]: CARD_COLOR.RED,
-    },
-    [CARD_DAYS.DAY3]: {
-        [CARD_OPTION.LEFT_OPTIONS]: CARD_COLOR.BLUE,
-        [CARD_OPTION.RIGHT_OPTIONS]: CARD_COLOR.RED,
-    },
-    [CARD_DAYS.DAY4]: {
-        [CARD_OPTION.LEFT_OPTIONS]: CARD_COLOR.GREEN,
-        [CARD_OPTION.RIGHT_OPTIONS]: CARD_COLOR.YELLOW,
-    },
-    [CARD_DAYS.DAY5]: {
-        [CARD_OPTION.LEFT_OPTIONS]: CARD_COLOR.GREEN,
-        [CARD_OPTION.RIGHT_OPTIONS]: CARD_COLOR.RED,
-    },
-    [CARD_DAYS.DAY6]: {
-        [CARD_OPTION.LEFT_OPTIONS]: CARD_COLOR.BLUE,
-        [CARD_OPTION.RIGHT_OPTIONS]: CARD_COLOR.YELLOW,
-    },
-};

--- a/client/src/features/RushGame/RushGameComponents/RushCardComparison.tsx
+++ b/client/src/features/RushGame/RushGameComponents/RushCardComparison.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 import { RushAPI } from "@/apis/rushAPI.ts";
-import { CARD_COLORS, CARD_DAYS, CARD_OPTION } from "@/constants/Rush/rushCard.ts";
+import { CARD_OPTION } from "@/constants/Rush/rushCard.ts";
 import { COOKIE_KEY } from "@/constants/cookie.ts";
 import RushCard from "@/features/RushGame/RushGameComponents/RushCard.tsx";
 import useFetch from "@/hooks/useFetch.ts";
 import { useRushGameContext } from "@/hooks/useRushGameContext.ts";
 import { GetTodayRushEventResponse, RushEventStatusCodeResponse } from "@/types/rushApi.ts";
 import { CardOption } from "@/types/rushGame.ts";
-
-const TEMP_CURRENT_DAY: (typeof CARD_DAYS)[keyof typeof CARD_DAYS] = CARD_DAYS.DAY1;
+import { getRandomCardColors } from "@/utils/getRandomCardColors.ts";
 
 const INITIAL_OPTION_NUMBER = -1 as const;
 
@@ -41,16 +40,17 @@ export default function RushCardComparison() {
 
     useEffect(() => {
         if (isSuccessTodayRushEvent && todayRushEventData) {
-            // TODO: 카드 색상 랜덤으로 변경
+            const { leftColor, rightColor } = getRandomCardColors();
+
             updateCardOptions(CARD_OPTION.LEFT_OPTIONS, {
                 mainText: todayRushEventData.leftOption.mainText,
                 subText: todayRushEventData.leftOption.subText,
-                color: CARD_COLORS[TEMP_CURRENT_DAY][CARD_OPTION.LEFT_OPTIONS],
+                color: leftColor,
             });
             updateCardOptions(CARD_OPTION.RIGHT_OPTIONS, {
                 mainText: todayRushEventData.rightOption.mainText,
                 subText: todayRushEventData.rightOption.subText,
-                color: CARD_COLORS[TEMP_CURRENT_DAY][CARD_OPTION.RIGHT_OPTIONS],
+                color: rightColor,
             });
         }
     }, [isSuccessTodayRushEvent, todayRushEventData]);

--- a/client/src/utils/getRandomCardColors.ts
+++ b/client/src/utils/getRandomCardColors.ts
@@ -1,13 +1,24 @@
 import { CARD_COLOR } from "@/constants/Rush/rushCard.ts";
 
+function getRandomTwoIndices(arrayLength: number): [number, number] {
+    if (arrayLength < 2) {
+        throw new Error("두 개의 고유 인덱스를 선택하려면 배열에 최소 2개의 요소가 있어야 합니다.");
+    }
+
+    const indices = Array.from({ length: arrayLength }, (_, i) => i);
+
+    for (let i = indices.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [indices[i], indices[j]] = [indices[j], indices[i]];
+    }
+
+    return [indices[0], indices[1]];
+}
+
 export function getRandomCardColors() {
     const colors = Object.values(CARD_COLOR);
-    const leftColorIdx = Math.floor(Math.random() * colors.length);
-    let rightColorIdx = Math.floor(Math.random() * colors.length);
 
-    while (rightColorIdx === leftColorIdx) {
-        rightColorIdx = Math.floor(Math.random() * colors.length);
-    }
+    const [leftColorIdx, rightColorIdx] = getRandomTwoIndices(colors.length);
 
     return {
         leftColor: colors[leftColorIdx],

--- a/client/src/utils/getRandomCardColors.ts
+++ b/client/src/utils/getRandomCardColors.ts
@@ -1,0 +1,16 @@
+import { CARD_COLOR } from "@/constants/Rush/rushCard.ts";
+
+export function getRandomCardColors() {
+    const colors = Object.values(CARD_COLOR);
+    const leftColorIdx = Math.floor(Math.random() * colors.length);
+    let rightColorIdx = Math.floor(Math.random() * colors.length);
+
+    while (rightColorIdx === leftColorIdx) {
+        rightColorIdx = Math.floor(Math.random() * colors.length);
+    }
+
+    return {
+        leftColor: colors[leftColorIdx],
+        rightColor: colors[rightColorIdx],
+    };
+}


### PR DESCRIPTION
## 🖥️ Preview
<img width="949" alt="image" src="https://github.com/user-attachments/assets/0f9c254a-bf14-4a0a-85f0-9f89c4076540">
<img width="938" alt="image" src="https://github.com/user-attachments/assets/78324eb1-f988-4443-b66c-69d91347b036">
<img width="939" alt="image" src="https://github.com/user-attachments/assets/c60f9c80-12b9-49c2-a74d-f1490718124c">
<img width="913" alt="image" src="https://github.com/user-attachments/assets/64fe2762-974e-4a00-9a0e-cb5c54400750">

close #167 

## ✏️ 한 일
- [x] RushCard 색상 랜덤 기능 구현

## ❗️ 발생한 이슈 (해결 방안)
```tsx
while (rightColorIdx === leftColorIdx) {
    rightColorIdx = Math.floor(Math.random() * colors.length);
}
```
두 카드의 색상이 겹치지 않도록 하기 위해서, 만약 동일한 색이 나올 경우 동일한 색이 나오지 않을 때까지 오른쪽 카드를 랜덤으로 계속 돌려주도록 구현했습니다.
## ❓ 논의가 필요한 사항
