### PR TITLE
[Fix] 선착순 미참여시 최종 결과 페이지 접근 오류

### DIFF
--- a/client/src/features/RushGame/RushGameSections/FinalResult.tsx
+++ b/client/src/features/RushGame/RushGameSections/FinalResult.tsx
@@ -66,7 +66,7 @@ export default function FinalResult({ unblockNavigation }: FinalResultProps) {
     const rightWinStatus = getWinStatus(rightOptionRatio, leftOptionRatio);
 
     function formatNumber(value?: number): string {
-        if (value === undefined) return "";
+        if (value === undefined || value === null) return "";
         return value.toLocaleString("en-US");
     }
 


### PR DESCRIPTION
## 🖥️ Preview
(없음)
close #192 

## ✏️ 한 일
- [x] 선착순 미참여시 최종 결과 페이지 접근 오류 처리

## ❗️ 발생한 이슈 (해결 방안)
```tsx
function formatNumber(value?: number): string {
    if (value === undefined || value === null) return "";
    return value.toLocaleString("en-US");
}

const formattedRank = formatNumber(rank);
const formattedTotalParticipants = formatNumber(totalParticipants);
```
최종 결과를 보여주는 화면에서 rank, totalParticipants가 null일 경우가 존재하지 않는다고 생각했다.
실제로 타입을 다음과 같이 정의해놨고 타입 추론도 number | undefined였기 때문이다.
```tsx
export interface GetRushResultResponse {
    optionId?: CardOption;
    isWinner?: boolean;
    leftOption: number;
    rightOption: number;
    rank?: number;
    totalParticipants?: number;
}
```
근데 보아하니 두 값들을 가져오는 resultData 자체가 null일 가능성이 존재했다. 
따라서 formatNumber 함수의 value 부분에 null도 추가로 처리해주었다. 

## ❓ 논의가 필요한 사항
