### PR TITLE
[Fix] 응답 완전히 반환 시 요청 보낼 수 있도록 isLoading 추가

### DIFF
--- a/client/src/features/RushGame/RushGameComponents/RushCardCurrentRatio.tsx
+++ b/client/src/features/RushGame/RushGameComponents/RushCardCurrentRatio.tsx
@@ -57,7 +57,7 @@ function getMessage(leftRatio: number, rightRatio: number, userSelectedOption: C
 export default function RushCardCurrentRatio() {
     const { userSelectedOption, cardOptions } = useRushGameStateContext();
     const { toggleContents } = useToggleContents();
-    const fetchRushBalance = useFetchRushBalance();
+    const { fetchRushBalance, isLoadingRushBalance } = useFetchRushBalance();
     const [throttle, setThrottle] = useState<boolean>(false);
 
     const leftOptionRatio = getOptionRatio({
@@ -81,7 +81,7 @@ export default function RushCardCurrentRatio() {
     });
 
     const reloadThrottleButton = () => {
-        if (!throttle) {
+        if (!throttle && !isLoadingRushBalance) {
             fetchRushBalance();
             setThrottle(true);
             setTimeout(() => {

--- a/client/src/features/RushGame/RushGameSections/SelectedCard.tsx
+++ b/client/src/features/RushGame/RushGameSections/SelectedCard.tsx
@@ -54,7 +54,7 @@ function SelectedCardCurrentRatio({ onClick }: SelectedCardDetailsProps) {
 
 export default function SelectedCard() {
     const { toggleContents, toggle } = useToggleContents({ useDuration: false });
-    const fetchRushBalance = useFetchRushBalance();
+    const { fetchRushBalance } = useFetchRushBalance();
 
     const selectedCardToggle = () => {
         toggle();

--- a/client/src/hooks/RushGame/useFetchRushBalance.ts
+++ b/client/src/hooks/RushGame/useFetchRushBalance.ts
@@ -15,6 +15,7 @@ export default function useFetchRushBalance() {
     const {
         data: rushBalanceData,
         isSuccess: isSuccessRushBalance,
+        isLoading: isLoadingRushBalance,
         fetchData: getRushBalance,
     } = useFetch<GetRushBalanceResponse, string>((token) => RushAPI.getRushBalance(token));
 
@@ -50,5 +51,5 @@ export default function useFetchRushBalance() {
         }
     }, [isSuccessRushBalance, rushBalanceData]);
 
-    return fetchRushBalance;
+    return { fetchRushBalance, isSuccessRushBalance, isLoadingRushBalance };
 }

--- a/client/src/hooks/RushGame/useFetchRushUserParticipationStatus.ts
+++ b/client/src/hooks/RushGame/useFetchRushUserParticipationStatus.ts
@@ -9,7 +9,7 @@ import { RUSH_ACTION } from "@/types/rushGame.ts";
 
 export function useFetchRushUserParticipationStatus() {
     const dispatch = useRushGameDispatchContext();
-    const fetchRushBalance = useFetchRushBalance();
+    const { fetchRushBalance } = useFetchRushBalance();
 
     const { data: userParticipatedStatus, fetchData: getRushUserParticipationStatus } = useFetch<
         GetRushUserParticipationStatusResponse,

--- a/client/src/hooks/useFetch.ts
+++ b/client/src/hooks/useFetch.ts
@@ -5,12 +5,14 @@ export default function useFetch<T, P = void>(fetch: (params: P) => Promise<T>, 
     const [data, setData] = useState<T | null>(null);
     const [isSuccess, setIsSuccess] = useState<boolean>(false);
     const [isError, setIsError] = useState<boolean>(false);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
 
     const { showBoundary } = useErrorBoundary();
 
     const fetchData = async (params?: P) => {
         setIsError(false);
         setIsSuccess(false);
+        setIsLoading(true);
 
         try {
             const data = await fetch(params as P);
@@ -22,8 +24,10 @@ export default function useFetch<T, P = void>(fetch: (params: P) => Promise<T>, 
             if (showError) {
                 showBoundary(error);
             }
+        } finally {
+            setIsLoading(false);
         }
     };
 
-    return { data, isSuccess, isError, fetchData };
+    return { data, isSuccess, isError, isLoading, fetchData };
 }


### PR DESCRIPTION
## 🖥️ Preview

### 전
https://github.com/user-attachments/assets/724cab7a-690d-4da6-8ba3-90dd4e98dc40

### 후
https://github.com/user-attachments/assets/12c63cbc-9f03-40ba-8215-df6d42cad1d6

close #198 

## ✏️ 한 일
- [x] 새로고침 요청 pending 쌓이는 오류

## ❗️ 발생한 이슈 (해결 방안)
요청을 보낼 때 pending이 3~4개씩 쌓이는 문제가 있었다. 
사실 다시 영상을 촬영하니 제대로 확인이 되지는 않았지만, 안정성을 위해 useFetch 훅에서 isLoading 상태를 추가하여, 요청이 완전히 반환 시에 true로 반환하고, 새로고침 버튼 throttle 로직에 조건문으로 추가해주었다.
따라서 요청이 완전히 반환되었을 때 다시 balance API 요청을 보낼 수 있도록 해주었다.

## ❓ 논의가 필요한 사항
