### PR TITLE
[Fix] getApplyCount dependency 수정

### DIFF
--- a/client/src/features/CasperCustom/CustomProcess/CasperCustomFinish.tsx
+++ b/client/src/features/CasperCustom/CustomProcess/CasperCustomFinish.tsx
@@ -74,7 +74,7 @@ export function CasperCustomFinish({
 
         unblockNavigation();
         getApplyCount();
-    }, [cookies]);
+    }, []);
 
     const handleSaveImage = () => {
         if (!casperCustomRef.current) {


### PR DESCRIPTION
## 🖥️ Preview



close #201

## ✏️ 한 일

- [x] 다른 탭에서 캐스퍼 봇 만들기를 했을 때 기존 탭 오류 발생

## ❗️ 발생한 이슈 (해결 방안)

다른 탭에서 캐스퍼 봇 만들기를 했을 때 기존 탭에 있던 cookie의 token이 변경되면서 getApplyCount 요청이 가게 됩니다. 그런데 이때 token이 아직 응모하지 않은 사용자의 token으로 바뀌면서 응모하지 않은 사용자라는 오류가 발생했습니다. 

따라서 dependency에서 cookie를 삭제해서 cookie가 바뀌어도 요청이 다시 발생하지 않게 수정했습니다.

## ❓ 논의가 필요한 사항
