### PR TITLE
[Fix] 카드 옵션 선택 시 POST 409 요청 오류

### DIFF
--- a/client/src/features/RushGame/RushGameComponents/RushCardComparison.tsx
+++ b/client/src/features/RushGame/RushGameComponents/RushCardComparison.tsx
@@ -24,7 +24,8 @@ export default function RushCardComparison() {
         isLoading: isLoadingPostSelectedRushOption,
         fetchData: postSelectedRushOptionApply,
     } = useFetch<RushEventStatusCodeResponse, { token: string; optionId: CardOption }>(
-        ({ token, optionId }) => RushAPI.postSelectedRushOptionApply(token, optionId)
+        ({ token, optionId }) => RushAPI.postSelectedRushOptionApply(token, optionId),
+        false
     );
 
     const handleCardSelection = async (optionId: CardOption) => {


### PR DESCRIPTION
## 🖥️ Preview
### 오류 화면

https://github.com/user-attachments/assets/a75452e5-d8ce-454e-90e2-ec4274c2ea68

<img width="1912" alt="스크린샷 2024-08-23 오후 4 15 15" src="https://github.com/user-attachments/assets/fadfeda9-881d-4e44-9308-2f48b5041878">
<img width="1912" alt="스크린샷 2024-08-23 오후 4 15 08" src="https://github.com/user-attachments/assets/a064dc8f-3909-45f2-afb7-35bfbb8c4d9e">


### 버그 수정 후 

https://github.com/user-attachments/assets/649fc73c-31d5-4a50-a67b-287ed35ac39e


close #200 

## ✏️ 한 일
카드 옵션 선택 시 카드 옵션 연타를 계속 하면 post 보낼 때 409 오류가 뜬다.
카드 연타할 경우 POST가 두 번 보내져서 이미 요청한 사용자에 대해서 계속 요청 보내지는 오류 발생하는 것이었다.
throttle 걸어줘서 POST 요청을 1초 정도 딜레이 줘서 요청이 한 번만 가도록 수정했다.

수정 후 몇 번이나 테스트했는데 409 오류는 발생하지 않았다. 
우연히 요청을 한 번밖에 못보낸 건지는 모르겠지만 우선 안전성을 위해 처리해뒀다.

```tsx
const [throttle, setThrottle] = useState<boolean>(false);

const {
    data: postSelectedRushOptionResponse,
    isSuccess: isSuccessPostSelectedRushOption,
    isLoading: isLoadingPostSelectedRushOption,
    fetchData: postSelectedRushOptionApply,
} = useFetch<RushEventStatusCodeResponse, { token: string; optionId: CardOption }>(
    ({ token, optionId }) => RushAPI.postSelectedRushOptionApply(token, optionId),
    false
);

const handleCardSelection = async (optionId: CardOption) => {
    if (!throttle && !isLoadingPostSelectedRushOption) {
        await postSelectedRushOptionApply({
            token: cookies[COOKIE_KEY.ACCESS_TOKEN],
            optionId,
        });
        dispatch({ type: RUSH_ACTION.SET_USER_OPTION, payload: optionId });
        setThrottle(true);
        setTimeout(() => {
            setThrottle(false);
        }, 1000);
    }
};
```

## ❗️ 발생한 이슈 (해결 방안)

## ❓ 논의가 필요한 사항
